### PR TITLE
Fix mailbox creation

### DIFF
--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -22,15 +22,8 @@ class PoweremailMailboxCRM(osv.osv):
             mail = qreu.Email(p_mail.pem_mail_orig)
             reply_to = mail.recipients.addresses
         else:
-            # If no mail source found, get recipients from pem
-            reply_mails = []
-            reply_mails.append(p_mail.pem_cc) \
-                if isinstance(
-                    p_mail.pem_cc, basestring
-                ) else reply_mails.append(', '.join(p_mail.pem_cc))
-            reply_mails.append(p_mail.pem_to)
-            reply_mails.append(p_mail.pem_bcc)
-            reply_to = ', '.join(reply_mails)
+            # If no mail source found, the mail is being sent
+            return res_id
         case_obj = self.pool.get('crm.case')
         section_obj = self.pool.get('crm.case.section')
         search_params = [('reply_to', 'in', reply_to)]

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -17,7 +17,7 @@ class PoweremailMailboxCRM(osv.osv):
         res_id = super(PoweremailMailboxCRM, self).create(cursor, uid, vals,
                                                           context)
         p_mail = self.browse(cursor, uid, res_id, context=context)
-        if vals['conversation_id']:
+        if vals.get('conversation_id', False):
             # If conversation exists, there's already a CRM Case
             return res_id
         mail = qreu.Email(p_mail.pem_mail_orig)

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -17,10 +17,16 @@ class PoweremailMailboxCRM(osv.osv):
         res_id = super(PoweremailMailboxCRM, self).create(cursor, uid, vals,
                                                           context)
         p_mail = self.browse(cursor, uid, res_id, context=context)
-        if vals.get('conversation_id', False):
-            # If conversation exists, there's already a CRM Case
+        # If original format mail, use it, else use txt or html
+        if p_mail.pem_mail_orig:
+            mail = qreu.Email(p_mail.pem_mail_orig)
+        elif p_mail.pem_body_text:
+            mail = qreu.Email(p_mail.pem_body_text)
+        elif p_mail.pem_body_html:
+            mail = qreu.Email(p_mail.pem_body_html)
+        else:
+            # If no mail source found, just save it as a Mail
             return res_id
-        mail = qreu.Email(p_mail.pem_mail_orig)
         case_obj = self.pool.get('crm.case')
         section_obj = self.pool.get('crm.case.section')
         reply_to = mail.recipients.addresses

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -17,6 +17,9 @@ class PoweremailMailboxCRM(osv.osv):
         res_id = super(PoweremailMailboxCRM, self).create(cursor, uid, vals,
                                                           context)
         p_mail = self.browse(cursor, uid, res_id, context=context)
+        if vals['conversation_id']:
+            # If conversation exists, there's already a CRM Case
+            return res_id
         mail = qreu.Email(p_mail.pem_mail_orig)
         case_obj = self.pool.get('crm.case')
         section_obj = self.pool.get('crm.case.section')

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -17,19 +17,15 @@ class PoweremailMailboxCRM(osv.osv):
         res_id = super(PoweremailMailboxCRM, self).create(cursor, uid, vals,
                                                           context)
         p_mail = self.browse(cursor, uid, res_id, context=context)
-        # If original format mail, use it, else use txt or html
+        # If original format mail, use it
         if p_mail.pem_mail_orig:
             mail = qreu.Email(p_mail.pem_mail_orig)
-        elif p_mail.pem_body_text:
-            mail = qreu.Email(p_mail.pem_body_text)
-        elif p_mail.pem_body_html:
-            mail = qreu.Email(p_mail.pem_body_html)
+            reply_to = mail.recipients.addresses
         else:
-            # If no mail source found, just save it as a Mail
-            return res_id
+            # If no mail source found, get recipients from pem
+            reply_to = p_mail.to + p_mail.cc + p_mail.bcc
         case_obj = self.pool.get('crm.case')
         section_obj = self.pool.get('crm.case.section')
-        reply_to = mail.recipients.addresses
         search_params = [('reply_to', 'in', reply_to)]
         section_id = section_obj.search(cursor, uid, search_params)
         if section_id:

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -23,7 +23,14 @@ class PoweremailMailboxCRM(osv.osv):
             reply_to = mail.recipients.addresses
         else:
             # If no mail source found, get recipients from pem
-            reply_to = p_mail.pem_to + p_mail.pem_cc + p_mail.pem_bcc
+            reply_mails = []
+            reply_mails.append(p_mail.pem_cc) \
+                if isinstance(
+                    p_mail.pem_cc, basestring
+                ) else reply_mails.append(', '.join(p_mail.pem_cc))
+            reply_mails.append(p_mail.pem_to)
+            reply_mails.append(p_mail.pem_bcc)
+            reply_to = ', '.join(reply_mails)
         case_obj = self.pool.get('crm.case')
         section_obj = self.pool.get('crm.case.section')
         search_params = [('reply_to', 'in', reply_to)]

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -23,7 +23,7 @@ class PoweremailMailboxCRM(osv.osv):
             reply_to = mail.recipients.addresses
         else:
             # If no mail source found, get recipients from pem
-            reply_to = p_mail.to + p_mail.cc + p_mail.bcc
+            reply_to = p_mail.pem_to + p_mail.pem_cc + p_mail.pem_bcc
         case_obj = self.pool.get('crm.case')
         section_obj = self.pool.get('crm.case.section')
         search_params = [('reply_to', 'in', reply_to)]


### PR DESCRIPTION
When answering a case, it was looking for the original mail (downloaded) to create a case.

If we're answering, a case must not be created. This may not work for all cases and we should review this first.

This patch only skips section finding and creating the case.

- [X] Solve mail sending bug ( cannot send mails from ERP)