### PR TITLE
[WIP] Fix crm rule view

### DIFF
--- a/crm.py
+++ b/crm.py
@@ -185,7 +185,7 @@ class CrmCaseRule(osv.osv):
         """
         ir_translation = self.pool.get('ir.translation')
         if not lang:
-            usr_obj = self.pool.get('res_users')
+            usr_obj = self.pool.get('res.users')
             usr_lang = usr_obj.read(cursor, uid, uid, ['context_lang'])
             if not usr_lang:
                 return src

--- a/crm.py
+++ b/crm.py
@@ -206,32 +206,32 @@ class CrmCaseRule(osv.osv):
             cr, uid, rule_id, case, context)
         action = self.pool.get('crm.case.rule').browse(cr, uid, rule_id)
         if action.pm_template_id:
-            try:
-                template_to = (
-                    Template(action.pm_template_id.def_to).render(object=case))
-            except:
-                raise osv.except_osv(_('Error!'), _(
-                    'Poweremail template "Email TO" has bad formatted address'))
-            if template_to:
+            if action.pm_template_id.def_to:
+                try:
+                    template_to = (
+                        Template(action.pm_template_id.def_to).render(object=case))
+                except:
+                    raise osv.except_osv(_('Error!'), _(
+                        'Poweremail template "Email TO" has bad formatted address'))
                 emails.append(template_to)
-            try:
-                template_cc = (
-                    Template(action.pm_template_id.def_cc).render(object=case))
-            except:
-                raise osv.except_osv(_('Error!'), _(
-                    'Poweremail template "Email CC" has bad formatted address'))
-            if template_cc:
+            if action.pm_template_id.def_cc:
+                try:
+                    template_cc = (
+                        Template(action.pm_template_id.def_cc).render(object=case))
+                except:
+                    raise osv.except_osv(_('Error!'), _(
+                        'Poweremail template "Email CC" has bad formatted address'))
                 emails += template_cc.split(',')
-            try:
-                template_bcc = (
-                    Template(action.pm_template_id.def_bcc).render(object=case))
-            except:
-                raise osv.except_osv(_('Error!'), _(
-                    'Poweremail template "Email BCC" has bad formatted'
-                    ' address'))
-            if template_bcc:
+            if action.pm_template_id.def_bcc:
+                try:
+                    template_bcc = (
+                        Template(action.pm_template_id.def_bcc).render(object=case))
+                except:
+                    raise osv.except_osv(_('Error!'), _(
+                        'Poweremail template "Email BCC" has bad formatted address'))
                 emails += template_bcc.split(',')
-        return emails
+
+        return list(set(emails))
 
     def get_email_body(self, cr, uid, rule_id, case, context=None):
         if not context:

--- a/crm.py
+++ b/crm.py
@@ -109,7 +109,7 @@ class CrmCase(osv.osv):
                         _('Can not send mail with empty body,you should have '
                           'description in the body'))
         for case in cases:
-            self.write(cr, uid, [case.id], {
+            self.write(cursor, uid, [case.id], {
                 'som': False,
                 'canal_id': False,
             })

--- a/crm.py
+++ b/crm.py
@@ -171,36 +171,7 @@ class CrmCaseRule(osv.osv):
         'pm_template_id': fields.many2one(
             'poweremail.templates', 'Poweremail Template', ondelete='restrict')
     }
-
-    def translate_body(self, cursor, uid, src, lang=False):
-        """Translate String.
-        :param cursor:      OpenERP Cursor
-        :param uid:     OpenERP User ID
-        :param src:     Source text to translate (aka email_body_text)
-        :type src: str
-        :param lang:    Target language of the translation
-        :type lang: str
-        :return:        Source text on "src" translated to language on "lang"
-                            If no language specified, using user's one
-        :rtype: str
-        """
-        ir_translation = self.pool.get('ir.translation')
-        if not lang:
-            usr_obj = self.pool.get('res.users')
-            usr_lang = usr_obj.read(cursor, uid, uid, ['context_lang'])
-            if not usr_lang:
-                return src
-            lang = usr_lang['context_lang']
-            if not lang:
-                return src
-        res = ir_translation._get_source(
-            cursor, uid, name='poweremail.templates,def_body_text',
-            lang=lang, tt='model', source=src
-        )
-        if not res:
-            return src
-        return res
-
+    
     def get_email_addresses(self, cr, uid, rule_id, case, context):
         if isinstance(rule_id, list):
             rule_id = rule_id[0]

--- a/crm.py
+++ b/crm.py
@@ -241,6 +241,8 @@ class CrmCaseRule(osv.osv):
             cr, uid, action_template, ['def_body_text', 'lang'])
         template_body = pm_template['def_body_text']
         template_lang = pm_template['lang'] or False
+        if template_lang:
+            template_lang = Template(template_lang).render(object=case)
         body = template_body or action_body
         body_mako_tpl = Template(
             self.translate_body(cr, uid, src=body, lang=template_lang),

--- a/crm.py
+++ b/crm.py
@@ -235,11 +235,19 @@ class CrmCaseRule(osv.osv):
         action_template = self.read(
             cr, uid, rule_id, ['pm_template_id'])['pm_template_id'][0]
         pm_template_obj = self.pool.get('poweremail.templates')
-        template_body = pm_template_obj.read(
-            cr, uid, action_template, ['def_body_text'])['def_body_text']
+        pm_template = pm_template_obj.read(
+            cr, uid, action_template, ['def_body_text', 'lang'])
+        template_body = pm_template['def_body_text']
+        template_lang = pm_template['lang'] or False
         body = template_body or action_body
-        rendered_body = Template(body).render(
-            object=case, date_now=datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
+        body_mako_tpl = Template(
+            self.translate_body(cr, uid, src=body, lang=template_lang),
+            input_encoding='utf-8',
+        )
+        rendered_body = body_mako_tpl.render(
+            object=case,
+            date_now=datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+        )
         return rendered_body
 
 

--- a/crm.py
+++ b/crm.py
@@ -67,6 +67,8 @@ class CrmCase(osv.osv):
             raise osv.except_osv(_('Error!'),
                     _("No E-Mail ID Found in Power Email for this section or "
                       "missing reply address in section."))
+        email_cc = context.get('email_cc', [])
+        email_cc.append(reply_to)
         # TODO: Improve reply-to finding in conversation
         pm_mailbox_obj.create(cursor, uid, {
             'pem_from': emailfrom,
@@ -78,7 +80,7 @@ class CrmCase(osv.osv):
             'date_mail': datetime.now().strftime('%Y-%m-%d'),
             'pem_message_id': make_msgid('tinycrm-%s' % case.id),
             'conversation_id': case.conversation_id.id,
-            'pem_cc': context.get('email_cc', False)
+            'pem_cc': ', '.join(set(email_cc))
         })
         return True
 

--- a/crm.py
+++ b/crm.py
@@ -182,18 +182,16 @@ class CrmCaseRule(osv.osv):
                 template_to = (
                     Template(action.pm_template_id.def_to).render(object=case))
             except:
-                raise osv.except_osv(_('Error!'), ('Poweremail template '
-                                                   '"Email TO" has bad '
-                                                   'formatted address'))
+                raise osv.except_osv(_('Error!'), _(
+                    'Poweremail template "Email TO" has bad formatted address'))
             if template_to:
                 emails.append(template_to)
             try:
                 template_cc = (
                     Template(action.pm_template_id.def_cc).render(object=case))
             except:
-                raise osv.except_osv(_('Error!'), ('Poweremail template '
-                                                   '"Email CC" has bad '
-                                                   'formatted address'))
+                raise osv.except_osv(_('Error!'), _(
+                    'Poweremail template "Email CC" has bad formatted address'))
             if template_cc:
                 emails += template_cc.split(',')
         return emails

--- a/crm.py
+++ b/crm.py
@@ -222,6 +222,14 @@ class CrmCaseRule(osv.osv):
                     'Poweremail template "Email CC" has bad formatted address'))
             if template_cc:
                 emails += template_cc.split(',')
+            try:
+                template_bcc = (
+                    Template(action.pm_template_id.def_bcc).render(object=case))
+            except:
+                raise osv.except_osv(_('Error!'), _(
+                    'Poweremail template "Email BCC" has bad formatted address'))
+            if template_bcc:
+                emails += template_bcc.split(',')
         return emails
 
     def get_email_body(self, cr, uid, rule_id, case, context=None):

--- a/crm.py
+++ b/crm.py
@@ -227,7 +227,8 @@ class CrmCaseRule(osv.osv):
                     Template(action.pm_template_id.def_bcc).render(object=case))
             except:
                 raise osv.except_osv(_('Error!'), _(
-                    'Poweremail template "Email BCC" has bad formatted address'))
+                    'Poweremail template "Email BCC" has bad formatted'
+                    ' address'))
             if template_bcc:
                 emails += template_bcc.split(',')
         return emails

--- a/crm.py
+++ b/crm.py
@@ -171,6 +171,24 @@ class CrmCaseRule(osv.osv):
             'poweremail.templates', 'Poweremail Template', ondelete='restrict')
     }
 
+    def get_email_addresses(self, cr, uid, rule_id, case, context):
+        if isinstance(rule_id, list):
+            rule_id = rule_id[0]
+        emails = super(CrmCaseRule, self).get_email_addresses(
+            cr, uid, rule_id, case, context)
+        action = self.pool.get('crm.case.rule').browse(cr, uid, rule_id)
+        if action.pm_template_id:
+            template_to = (
+                Template(action.pm_template_id.def_to).render(object=case))
+            if template_to:
+                emails.append(template_to)
+            template_cc = (
+                Template(action.pm_template_id.def_cc).render(object=case))
+            if template_cc:
+                emails += template_cc.split(',')
+        return emails
+
+
     def get_email_body(self, cr, uid, rule_id, case, context=None):
         if not context:
             context = {}

--- a/crm.py
+++ b/crm.py
@@ -178,16 +178,25 @@ class CrmCaseRule(osv.osv):
             cr, uid, rule_id, case, context)
         action = self.pool.get('crm.case.rule').browse(cr, uid, rule_id)
         if action.pm_template_id:
-            template_to = (
-                Template(action.pm_template_id.def_to).render(object=case))
+            try:
+                template_to = (
+                    Template(action.pm_template_id.def_to).render(object=case))
+            except:
+                raise osv.except_osv(_('Error!'), ('Poweremail template '
+                                                   '"Email TO" has bad '
+                                                   'formatted address'))
             if template_to:
                 emails.append(template_to)
-            template_cc = (
-                Template(action.pm_template_id.def_cc).render(object=case))
+            try:
+                template_cc = (
+                    Template(action.pm_template_id.def_cc).render(object=case))
+            except:
+                raise osv.except_osv(_('Error!'), ('Poweremail template '
+                                                   '"Email CC" has bad '
+                                                   'formatted address'))
             if template_cc:
                 emails += template_cc.split(',')
         return emails
-
 
     def get_email_body(self, cr, uid, rule_id, case, context=None):
         if not context:

--- a/crm.py
+++ b/crm.py
@@ -193,7 +193,9 @@ class CrmCaseRule(osv.osv):
             if not lang:
                 return src
         res = ir_translation._get_source(
-            cursor, uid, name=src, lang=lang, tt='model')
+            cursor, uid, name='poweremail.templates,def_body_text',
+            lang=lang, tt='model', source=src
+        )
         if not res:
             return src
         return res

--- a/crm.py
+++ b/crm.py
@@ -171,6 +171,33 @@ class CrmCaseRule(osv.osv):
             'poweremail.templates', 'Poweremail Template', ondelete='restrict')
     }
 
+    def translate_body(self, cursor, uid, src, lang=False):
+        """Translate String.
+        :param cursor:      OpenERP Cursor
+        :param uid:     OpenERP User ID
+        :param src:     Source text to translate (aka email_body_text)
+        :type src: str
+        :param lang:    Target language of the translation
+        :type lang: str
+        :return:        Source text on "src" translated to language on "lang"
+                            If no language specified, using user's one
+        :rtype: str
+        """
+        ir_translation = self.pool.get('ir.translation')
+        if not lang:
+            usr_obj = self.pool.get('res_users')
+            usr_lang = usr_obj.read(cursor, uid, uid, ['context_lang'])
+            if not usr_lang:
+                return src
+            lang = usr_lang['context_lang']
+            if not lang:
+                return src
+        res = ir_translation._get_source(
+            cursor, uid, name=src, lang=lang, tt='model')
+        if not res:
+            return src
+        return res
+
     def get_email_addresses(self, cr, uid, rule_id, case, context):
         if isinstance(rule_id, list):
             rule_id = rule_id[0]

--- a/crm.py
+++ b/crm.py
@@ -108,13 +108,11 @@ class CrmCase(osv.osv):
                 raise osv.except_osv(_('Error!'),
                         _('Can not send mail with empty body,you should have '
                           'description in the body'))
-        self._history(cursor, uid, cases, _('Send'), history=True, email=False)
         for case in cases:
-            self.write(cursor, uid, [case.id], {
-                'description': False,
+            self.write(cr, uid, [case.id], {
                 'som': False,
                 'canal_id': False,
-                })
+            })
             emails = [case.email_from]
             if case.email_cc:
                 context['email_cc'] = ', '.join(
@@ -128,6 +126,7 @@ class CrmCase(osv.osv):
                 raise osv.except_osv(_('Error!'),
                         _("No E-Mail ID Found for your Company address!"))
             self.email_send(cursor, uid, case, emails, body, context)
+        self._history(cursor, uid, cases, _('Send'), history=True, email=False)
         return True
 
     def _conversation_mails(self, cursor, uid, ids, field_name, args,

--- a/crm.py
+++ b/crm.py
@@ -223,7 +223,9 @@ class CrmCaseRule(osv.osv):
                 except:
                     raise osv.except_osv(_('Error!'), _(
                         'Poweremail template "Email CC" has bad formatted address'))
-                emails += template_cc.split(',')
+                context.update({
+                    'email_cc': list(set(template_cc.split(',')))
+                })
             if action.pm_template_id.def_bcc:
                 try:
                     template_bcc = (
@@ -231,7 +233,9 @@ class CrmCaseRule(osv.osv):
                 except:
                     raise osv.except_osv(_('Error!'), _(
                         'Poweremail template "Email BCC" has bad formatted address'))
-                emails += template_bcc.split(',')
+                context.update({
+                    'email_bcc': list(set(template_bcc.split(',')))
+                })
 
         return list(set(emails))
 

--- a/crm_data.xml
+++ b/crm_data.xml
@@ -13,10 +13,12 @@
             <field name="lang" eval="False"/>
             <field name="save_to_drafts" eval="True"/>
             <field name="def_body_text"> Dear ${object.partner_id.name},
-
-In date ${date_now} the case has been Opened with the subject: ${object.name}
+${from datetime import datetime}
+In date ${date_now} the case has been Opened with the subject: ${upper(object.name)}
 Case Identifier: #${object.id}
-Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}</field>
+Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}
+
+            </field>
         </record>
         <record model="poweremail.templates" id="crm_poweremail_case_template_pending">
             <field name="name">Pending Case Template</field>
@@ -32,7 +34,9 @@ Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}</field>
 
 The case with identifier: #${object.id} with the subject: "${upper(object.name)}" has been updated to the state 'Pending'.
 
-Awaiting for review.</field>
+Awaiting for review.
+
+            </field>
         </record>
         <record model="poweremail.templates" id="crm_poweremail_case_template_close">
             <field name="name">Close Case Template</field>
@@ -46,7 +50,9 @@ Awaiting for review.</field>
             <field name="save_to_drafts" eval="True"/>
             <field name="def_body_text"> Dear ${object.partner_id.name},
 
-The case with identifier: #${object.id} with the subject: "${upper(object.name)}" has been CLOSED.</field>
+The case with identifier: #${object.id} with the subject: "${upper(object.name)}" has been CLOSED.
+
+            </field>
         </record>
 
         <!-- CRM - Rules -->
@@ -57,22 +63,34 @@ The case with identifier: #${object.id} with the subject: "${upper(object.name)}
             <field name="trg_state_from">draft</field>
             <field name="trg_state_to">open</field>
             <field name="pm_template_id" ref="crm_poweremail_case_template_open"/>
+            <field name="act_mail_to_user" eval="True"/>
+            <field name="act_mail_to_partner" eval="True"/>
+            <field name="act_mail_to_watchers" eval="True"/>
+            <field name="act_mail_to_email" eval="True"/>
         </record>
 
         <record model="crm.case.rule" id="crm_poweremail_rule_pending">
-            <field name="name">Poweremail Open Case</field>
+            <field name="name">Poweremail Pending Case</field>
             <field name="active">True</field>
             <field name="trg_state_from">open</field>
             <field name="trg_state_to">pending</field>
             <field name="pm_template_id" ref="crm_poweremail_case_template_pending"/>
+            <field name="act_mail_to_user" eval="True"/>
+            <field name="act_mail_to_partner" eval="True"/>
+            <field name="act_mail_to_watchers" eval="True"/>
+            <field name="act_mail_to_email" eval="True"/>
         </record>
 
         <record model="crm.case.rule" id="crm_poweremail_rule_close">
-            <field name="name">Poweremail Open Case</field>
+            <field name="name">Poweremail Close Case</field>
             <field name="active">True</field>
             <field name="trg_state_from">pending</field>
             <field name="trg_state_to">done</field>
             <field name="pm_template_id" ref="crm_poweremail_case_template_close"/>
+            <field name="act_mail_to_user" eval="True"/>
+            <field name="act_mail_to_partner" eval="True"/>
+            <field name="act_mail_to_watchers" eval="True"/>
+            <field name="act_mail_to_email" eval="True"/>
         </record>
     </data>
 </openerp>

--- a/crm_data.xml
+++ b/crm_data.xml
@@ -2,6 +2,25 @@
 <openerp>
     <data>
         <!-- CRM Poweremail - Templates -->
+        <record model="poweremail.templates" id="crm_poweremail_case_template_new">
+            <field name="name">New Case Template</field>
+            <field name="object_name" model="ir.model" search="[('model', '=', 'crm.case')]"/>
+            <field name="def_to">${object.email_from}</field>
+            <field name="def_cc">${object.email_cc}</field>
+            <field name="def_subject" >${object.name}</field>
+            <field name="template_language">mako</field>
+            <field name="use_sign" eval="False"/>
+            <field name="lang" eval="False"/>
+            <field name="save_to_drafts" eval="True"/>
+            <field name="def_body_text">Dear ${object.partner_id.name},
+
+In date ${date_now} we have recieved the case with the subject: ${object.name}
+Case Identifier: #${object.id}
+
+Waiting for a responsible to take over the case.
+
+            </field>
+        </record>
         <record model="poweremail.templates" id="crm_poweremail_case_template_open">
             <field name="name">Open Case Template</field>
             <field name="object_name" model="ir.model" search="[('model', '=', 'crm.case')]"/>

--- a/crm_data.xml
+++ b/crm_data.xml
@@ -84,7 +84,8 @@ The case with identifier: #${object.id} with the subject: "${object.name}" has b
             <field name="active">True</field>
             <field name="trg_state_from">draft</field>
             <field name="trg_date_type">create</field>
-            <field name="trg_max_history" eval="1"/>
+            <field name="trg_max_history" eval="0"/>
+            <field name="trg_limit_history" eval="1"/>
             <field name="pm_template_id" ref="crm_poweremail_case_template_new"/>
         </record>
 

--- a/crm_data.xml
+++ b/crm_data.xml
@@ -8,6 +8,7 @@
             <field name="def_to">${object.email_from}</field>
             <field name="def_cc">${object.email_cc}</field>
             <field name="def_subject" >${object.name}</field>
+            <field name="lang" >${object.partner_id.lang}</field>
             <field name="template_language">mako</field>
             <field name="use_sign" eval="False"/>
             <field name="lang" eval="False"/>
@@ -27,9 +28,9 @@ Waiting for a responsible to take over the case.
             <field name="def_to">${object.user_id.address_id.email}</field>
             <field name="def_cc">${object.email_cc}</field>
             <field name="def_subject" >${object.name}</field>
+            <field name="lang" >${object.partner_id.lang}</field>
             <field name="template_language">mako</field>
             <field name="use_sign" eval="False"/>
-            <field name="lang" eval="False"/>
             <field name="save_to_drafts" eval="True"/>
             <field name="def_body_text">Dear ${object.partner_id.name},
 
@@ -45,9 +46,9 @@ Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}
             <field name="def_to">${object.user_id.address_id.email}</field>
             <field name="def_cc">${object.email_cc}</field>
             <field name="def_subject" >${object.name}</field>
+            <field name="lang" >${object.partner_id.lang}</field>
             <field name="template_language">mako</field>
             <field name="use_sign" eval="False"/>
-            <field name="lang" eval="False"/>
             <field name="save_to_drafts" eval="True"/>
             <field name="def_body_text">Dear ${object.partner_id.name},
 
@@ -63,9 +64,9 @@ Awaiting for review.
             <field name="def_to">${object.user_id.address_id.email}</field>
             <field name="def_cc">${object.email_cc}</field>
             <field name="def_subject" >${object.name}</field>
+            <field name="lang" >${object.partner_id.lang}</field>
             <field name="template_language">mako</field>
             <field name="use_sign" eval="False"/>
-            <field name="lang" eval="False"/>
             <field name="save_to_drafts" eval="True"/>
             <field name="def_body_text">Dear ${object.partner_id.name},
 

--- a/crm_data.xml
+++ b/crm_data.xml
@@ -12,7 +12,7 @@
             <field name="use_sign" eval="False"/>
             <field name="lang" eval="False"/>
             <field name="save_to_drafts" eval="True"/>
-            <field name="def_body_text"> Dear ${object.partner_id.name},
+            <field name="def_body_text">Dear ${object.partner_id.name},
 
 In date ${date_now} the case has been Opened with the subject: ${object.name}
 Case Identifier: #${object.id}
@@ -30,7 +30,7 @@ Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}
             <field name="use_sign" eval="False"/>
             <field name="lang" eval="False"/>
             <field name="save_to_drafts" eval="True"/>
-            <field name="def_body_text"> Dear ${object.partner_id.name},
+            <field name="def_body_text">Dear ${object.partner_id.name},
 
 The case with identifier: #${object.id} with the subject: "${object.name}" has been updated to the state 'Pending'.
 
@@ -48,9 +48,9 @@ Awaiting for review.
             <field name="use_sign" eval="False"/>
             <field name="lang" eval="False"/>
             <field name="save_to_drafts" eval="True"/>
-            <field name="def_body_text"> Dear ${object.partner_id.name},
+            <field name="def_body_text">Dear ${object.partner_id.name},
 
-The case with identifier: #${object.id} with the subject: "${object.name)}" has been CLOSED.
+The case with identifier: #${object.id} with the subject: "${object.name}" has been CLOSED.
 
             </field>
         </record>

--- a/crm_data.xml
+++ b/crm_data.xml
@@ -65,8 +65,6 @@ The case with identifier: #${object.id} with the subject: "${object.name}" has b
             <field name="pm_template_id" ref="crm_poweremail_case_template_open"/>
             <field name="act_mail_to_user" eval="True"/>
             <field name="act_mail_to_partner" eval="True"/>
-            <field name="act_mail_to_watchers" eval="True"/>
-            <field name="act_mail_to_email" eval="True"/>
         </record>
 
         <record model="crm.case.rule" id="crm_poweremail_rule_pending">
@@ -77,8 +75,6 @@ The case with identifier: #${object.id} with the subject: "${object.name}" has b
             <field name="pm_template_id" ref="crm_poweremail_case_template_pending"/>
             <field name="act_mail_to_user" eval="True"/>
             <field name="act_mail_to_partner" eval="True"/>
-            <field name="act_mail_to_watchers" eval="True"/>
-            <field name="act_mail_to_email" eval="True"/>
         </record>
 
         <record model="crm.case.rule" id="crm_poweremail_rule_close">
@@ -89,8 +85,6 @@ The case with identifier: #${object.id} with the subject: "${object.name}" has b
             <field name="pm_template_id" ref="crm_poweremail_case_template_close"/>
             <field name="act_mail_to_user" eval="True"/>
             <field name="act_mail_to_partner" eval="True"/>
-            <field name="act_mail_to_watchers" eval="True"/>
-            <field name="act_mail_to_email" eval="True"/>
         </record>
     </data>
 </openerp>

--- a/crm_data.xml
+++ b/crm_data.xml
@@ -25,8 +25,9 @@ Waiting for a responsible to take over the case.
         <record model="poweremail.templates" id="crm_poweremail_case_template_open">
             <field name="name">Open Case Template</field>
             <field name="object_name" model="ir.model" search="[('model', '=', 'crm.case')]"/>
-            <field name="def_to">${object.user_id.address_id.email}</field>
+            <field name="def_to">${object.email_from}</field>
             <field name="def_cc">${object.email_cc}</field>
+            <field name="def_bcc">${object.user_id.address_id.email}</field>
             <field name="def_subject" >${object.name}</field>
             <field name="lang" >${object.partner_id.lang}</field>
             <field name="template_language">mako</field>
@@ -43,8 +44,9 @@ Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}
         <record model="poweremail.templates" id="crm_poweremail_case_template_pending">
             <field name="name">Pending Case Template</field>
             <field name="object_name" model="ir.model" search="[('model', '=', 'crm.case')]"/>
-            <field name="def_to">${object.user_id.address_id.email}</field>
+            <field name="def_to">${object.email_from}</field>
             <field name="def_cc">${object.email_cc}</field>
+            <field name="def_bcc">${object.user_id.address_id.email}</field>
             <field name="def_subject" >${object.name}</field>
             <field name="lang" >${object.partner_id.lang}</field>
             <field name="template_language">mako</field>
@@ -61,8 +63,9 @@ Awaiting for review.
         <record model="poweremail.templates" id="crm_poweremail_case_template_close">
             <field name="name">Close Case Template</field>
             <field name="object_name" model="ir.model" search="[('model', '=', 'crm.case')]"/>
-            <field name="def_to">${object.user_id.address_id.email}</field>
+            <field name="def_to">${object.email_from}</field>
             <field name="def_cc">${object.email_cc}</field>
+            <field name="def_bcc">${object.user_id.address_id.email}</field>
             <field name="def_subject" >${object.name}</field>
             <field name="lang" >${object.partner_id.lang}</field>
             <field name="template_language">mako</field>

--- a/crm_data.xml
+++ b/crm_data.xml
@@ -14,7 +14,7 @@
             <field name="save_to_drafts" eval="True"/>
             <field name="def_body_text"> Dear ${object.partner_id.name},
 ${from datetime import datetime}
-In date ${date_now} the case has been Opened with the subject: ${upper(object.name)}
+In date ${date_now} the case has been Opened with the subject: ${object.name}
 Case Identifier: #${object.id}
 Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}
 
@@ -32,7 +32,7 @@ Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}
             <field name="save_to_drafts" eval="True"/>
             <field name="def_body_text"> Dear ${object.partner_id.name},
 
-The case with identifier: #${object.id} with the subject: "${upper(object.name)}" has been updated to the state 'Pending'.
+The case with identifier: #${object.id} with the subject: "${object.name}" has been updated to the state 'Pending'.
 
 Awaiting for review.
 
@@ -50,7 +50,7 @@ Awaiting for review.
             <field name="save_to_drafts" eval="True"/>
             <field name="def_body_text"> Dear ${object.partner_id.name},
 
-The case with identifier: #${object.id} with the subject: "${upper(object.name)}" has been CLOSED.
+The case with identifier: #${object.id} with the subject: "${object.name)}" has been CLOSED.
 
             </field>
         </record>

--- a/crm_data.xml
+++ b/crm_data.xml
@@ -56,6 +56,14 @@ The case with identifier: #${object.id} with the subject: "${object.name}" has b
         </record>
 
         <!-- CRM - Rules -->
+        <record model="crm.case.rule" id="crm_poweremail_rule_new">
+            <field name="name">Poweremail New Case</field>
+            <field name="active">True</field>
+            <field name="trg_state_from">draft</field>
+            <field name="trg_date_type">create</field>
+            <field name="trg_max_history" eval="1"/>
+            <field name="pm_template_id" ref="crm_poweremail_case_template_new"/>
+        </record>
 
         <record model="crm.case.rule" id="crm_poweremail_rule_open">
             <field name="name">Poweremail Open Case</field>

--- a/crm_data.xml
+++ b/crm_data.xml
@@ -13,7 +13,7 @@
             <field name="lang" eval="False"/>
             <field name="save_to_drafts" eval="True"/>
             <field name="def_body_text"> Dear ${object.partner_id.name},
-${from datetime import datetime}
+
 In date ${date_now} the case has been Opened with the subject: ${object.name}
 Case Identifier: #${object.id}
 Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}

--- a/i18n/ca_ES.po
+++ b/i18n/ca_ES.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GISCE-ERP\n"
 "Report-Msgid-Bugs-To: https://github.com/gisce/erp/issues\n"
-"POT-Creation-Date: 2017-09-29 13:38\n"
-"PO-Revision-Date: 2017-09-29 11:47+0000\n"
+"POT-Creation-Date: 2017-10-05 10:02\n"
+"PO-Revision-Date: 2017-10-05 08:12+0000\n"
 "Last-Translator: Jaume  Florez Valenzuela <jflorez@gisce.net>\n"
 "Language-Team: Catalan (Spain) <erp@dev.gisce.net>\n"
 "MIME-Version: 1.0\n"
@@ -16,18 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Language: ca_ES\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
-#. module: crm_poweremail
-#: field:crm.case.rule,pm_template_id:0
-msgid "Poweremail Template"
-msgstr "Plantilla Poweremail"
-
-#. module: crm_poweremail
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_open
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_pending
-msgid "${object.name}"
-msgstr "${object.name}"
 
 #. module: crm_poweremail
 #: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_pending
@@ -42,16 +30,15 @@ msgid ""
 msgstr "Estimat/ada ${object.partner_id.name},\n\nEl cas amb l'identificador: #${object.id} amb l'assumpte: \"${object.name}\" s'ha actualitzat al estat 'Pending'.\n\nEsperant la revisió.\n\n            "
 
 #. module: crm_poweremail
-#: field:crm.case,conversation_mails:0
-msgid "unknown"
-msgstr "desconegut"
+#: field:crm.case.rule,pm_template_id:0
+msgid "Poweremail Template"
+msgstr "Plantilla Poweremail"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:109
+#: code:addons/crm_poweremail/crm.py:220
 #, python-format
-msgid ""
-"Can not send mail with empty body,you should have description in the body"
-msgstr "No es pot enviar un correu amb el cos buit, hauria d'haver una descripció en el cos del missatge"
+msgid "Poweremail template \"Email CC\" has bad formatted address"
+msgstr "La direcció \"CC\" de la plantilla Power E-mail no té un format correcte"
 
 #. module: crm_poweremail
 #: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
@@ -63,7 +50,24 @@ msgid ""
 "Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}\n"
 "\n"
 "            "
-msgstr "Estimat/ada ${object.partner_id.name},\n\nEn data ${date_now} s'ha Obert un cas amb l'assumpte: ${object.name}\nIdentificador del cas: #${object.id}\nResponsable: ${object.user_id.name} - ${object.user_id.address_id.email}\n\n            "
+msgstr "Estimat/ada ${object.partner_id.name},\n\nEn data ${date_now} s'ha Obert un cas amb l'assumpte: ${object.name}\n\nIdentificador del cas: #${object.id}\nResponsable: ${object.user_id.name} - ${object.user_id.address_id.email}\n\n            "
+
+#. module: crm_poweremail
+#: view:crm.case:0
+msgid "Conversations"
+msgstr "Converses"
+
+#. module: crm_poweremail
+#: field:crm.case,conversation_mails:0
+msgid "unknown"
+msgstr "desconegut"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:109
+#, python-format
+msgid ""
+"Can not send mail with empty body,you should have description in the body"
+msgstr "No es pot enviar un correu amb el cos buit, hauria d'haver una descripció en el cos del missatge"
 
 #. module: crm_poweremail
 #: code:addons/crm_poweremail/crm.py:129
@@ -77,14 +81,31 @@ msgid "Invalid XML for View Architecture!"
 msgstr "Arquitectura del XML invàlida!"
 
 #. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:212
+#, python-format
+msgid "Poweremail template \"Email TO\" has bad formatted address"
+msgstr "La direcció \"TO\" de la plantilla Power E-mail no té un format correcte"
+
+#. module: crm_poweremail
 #: view:crm.case.rule:0
 msgid "E-Mail Actions"
 msgstr "Accions de correu electrònic"
 
 #. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close
+msgid ""
+"Dear ${object.partner_id.name},\n"
+"\n"
+"The case with identifier: #${object.id} with the subject: \"${object.name}\" has been CLOSED.\n"
+"\n"
+"            "
+msgstr "Estimat/ada ${object.partner_id.name},\n\nEl cas amb l'identificador: #${object.id} amb l'assumpte: \"${object.name}\" s'ha TANCAT.\n\n            "
+
+#. module: crm_poweremail
 #: code:addons/crm_poweremail/crm.py:60 code:addons/crm_poweremail/crm.py:67
 #: code:addons/crm_poweremail/crm.py:101 code:addons/crm_poweremail/crm.py:104
 #: code:addons/crm_poweremail/crm.py:108 code:addons/crm_poweremail/crm.py:128
+#: code:addons/crm_poweremail/crm.py:212 code:addons/crm_poweremail/crm.py:220
 #, python-format
 msgid "Error!"
 msgstr "Error!"
@@ -130,11 +151,6 @@ msgid "CRM Poweremail"
 msgstr "CRM Poweremail"
 
 #. module: crm_poweremail
-#: view:crm.case:0
-msgid "Conversations"
-msgstr "Converses"
-
-#. module: crm_poweremail
 #: field:crm.case,conversation_id:0
 msgid "Conversation"
 msgstr "Conversa"
@@ -156,6 +172,13 @@ msgid "You must put a Partner eMail to use this action!"
 msgstr "S'ha d'introduïr el correu electrònic de l'Empresa per poder utilitzar aquesta acció"
 
 #. module: crm_poweremail
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_open
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_pending
+msgid "${object.name}"
+msgstr "${object.name}"
+
+#. module: crm_poweremail
 #: model:ir.module.module,description:crm_poweremail.module_meta_information
 msgid ""
 "\n"
@@ -166,13 +189,3 @@ msgid ""
 "          See: https://github.com/openlabs/poweremail/issues/24\n"
 "    "
 msgstr "\n    Aquest mòdul proveeix :\n        * Integració entre CRM i Poweremail\n        \n    NOTA: Es necessita poweremail amb suport per converses.\n          See: https://github.com/openlabs/poweremail/issues/24\n    "
-
-#. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close
-msgid ""
-"Dear ${object.partner_id.name},\n"
-"\n"
-"The case with identifier: #${object.id} with the subject: \"${object.name}\" has been CLOSED.\n"
-"\n"
-"            "
-msgstr "Estimat/ada ${object.partner_id.name},\n\nEl cas amb l'identificador: #${object.id} amb l'assumpte: \"${object.name}\" s'ha TANCAT.\n\n            "

--- a/i18n/ca_ES.po
+++ b/i18n/ca_ES.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GISCE-ERP\n"
 "Report-Msgid-Bugs-To: https://github.com/gisce/erp/issues\n"
-"POT-Creation-Date: 2017-10-05 10:02\n"
-"PO-Revision-Date: 2017-10-05 08:12+0000\n"
+"POT-Creation-Date: 2017-10-06 11:52\n"
+"PO-Revision-Date: 2017-10-06 10:00+0000\n"
 "Last-Translator: Jaume  Florez Valenzuela <jflorez@gisce.net>\n"
 "Language-Team: Catalan (Spain) <erp@dev.gisce.net>\n"
 "MIME-Version: 1.0\n"
@@ -35,10 +35,29 @@ msgid "Poweremail Template"
 msgstr "Plantilla Poweremail"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:220
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_new
+msgid ""
+"Dear ${object.partner_id.name},\n"
+"\n"
+"In date ${date_now} we have recieved the case with the subject: ${object.name}\n"
+"Case Identifier: #${object.id}\n"
+"\n"
+"Waiting for a responsible to take over the case.\n"
+"\n"
+"            "
+msgstr "Estimat/ada ${object.partner_id.name},\n\nEn data ${date_now} s'ha rebut un cas amb l'assumpte: ${object.name}\n\nIdentificador del cas: #${object.id}\n\nEsperant l'assignació d'un responsable.\n\n            "
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:221
 #, python-format
 msgid "Poweremail template \"Email CC\" has bad formatted address"
 msgstr "La direcció \"CC\" de la plantilla Power E-mail no té un format correcte"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/poweremail_mailbox.py:72
+#, python-format
+msgid "Reply"
+msgstr "Resposta"
 
 #. module: crm_poweremail
 #: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
@@ -70,7 +89,7 @@ msgid ""
 msgstr "No es pot enviar un correu amb el cos buit, hauria d'haver una descripció en el cos del missatge"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:129
+#: code:addons/crm_poweremail/crm.py:127
 #, python-format
 msgid "No E-Mail ID Found for your Company address!"
 msgstr "No s'ha trobat la ID del correu electrònic de la direcció de la seva Companyia"
@@ -81,7 +100,7 @@ msgid "Invalid XML for View Architecture!"
 msgstr "Arquitectura del XML invàlida!"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:212
+#: code:addons/crm_poweremail/crm.py:213
 #, python-format
 msgid "Poweremail template \"Email TO\" has bad formatted address"
 msgstr "La direcció \"TO\" de la plantilla Power E-mail no té un format correcte"
@@ -104,8 +123,8 @@ msgstr "Estimat/ada ${object.partner_id.name},\n\nEl cas amb l'identificador: #$
 #. module: crm_poweremail
 #: code:addons/crm_poweremail/crm.py:60 code:addons/crm_poweremail/crm.py:67
 #: code:addons/crm_poweremail/crm.py:101 code:addons/crm_poweremail/crm.py:104
-#: code:addons/crm_poweremail/crm.py:108 code:addons/crm_poweremail/crm.py:128
-#: code:addons/crm_poweremail/crm.py:212 code:addons/crm_poweremail/crm.py:220
+#: code:addons/crm_poweremail/crm.py:108 code:addons/crm_poweremail/crm.py:126
+#: code:addons/crm_poweremail/crm.py:213 code:addons/crm_poweremail/crm.py:221
 #, python-format
 msgid "Error!"
 msgstr "Error!"
@@ -127,7 +146,7 @@ msgid ""
 msgstr "No s'ha trobat el ID del correu electrònic de la seva Companyia o falta el correu electrònic de resposta per aquesta secció!"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:111
+#: code:addons/crm_poweremail/crm.py:129
 #, python-format
 msgid "Send"
 msgstr "Enviar"
@@ -173,6 +192,7 @@ msgstr "S'ha d'introduïr el correu electrònic de l'Empresa per poder utilitzar
 
 #. module: crm_poweremail
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_new
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_open
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_pending
 msgid "${object.name}"

--- a/i18n/ca_ES.po
+++ b/i18n/ca_ES.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GISCE-ERP\n"
 "Report-Msgid-Bugs-To: https://github.com/gisce/erp/issues\n"
-"POT-Creation-Date: 2017-10-06 11:52\n"
-"PO-Revision-Date: 2017-10-06 10:00+0000\n"
+"POT-Creation-Date: 2017-10-06 13:40\n"
+"PO-Revision-Date: 2017-10-06 11:42+0000\n"
 "Last-Translator: Jaume  Florez Valenzuela <jflorez@gisce.net>\n"
 "Language-Team: Catalan (Spain) <erp@dev.gisce.net>\n"
 "MIME-Version: 1.0\n"
@@ -16,6 +16,12 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Language: ca_ES\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:229
+#, python-format
+msgid "Poweremail template \"Email BCC\" has bad formatted address"
+msgstr "La direcció \"BCC\" de la plantilla Power E-mail no té un format correcte"
 
 #. module: crm_poweremail
 #: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_pending
@@ -125,6 +131,7 @@ msgstr "Estimat/ada ${object.partner_id.name},\n\nEl cas amb l'identificador: #$
 #: code:addons/crm_poweremail/crm.py:101 code:addons/crm_poweremail/crm.py:104
 #: code:addons/crm_poweremail/crm.py:108 code:addons/crm_poweremail/crm.py:126
 #: code:addons/crm_poweremail/crm.py:213 code:addons/crm_poweremail/crm.py:221
+#: code:addons/crm_poweremail/crm.py:229
 #, python-format
 msgid "Error!"
 msgstr "Error!"

--- a/i18n/ca_ES.po
+++ b/i18n/ca_ES.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GISCE-ERP\n"
 "Report-Msgid-Bugs-To: https://github.com/gisce/erp/issues\n"
-"POT-Creation-Date: 2017-09-25 14:17\n"
-"PO-Revision-Date: 2017-09-25 12:47+0000\n"
+"POT-Creation-Date: 2017-09-29 13:38\n"
+"PO-Revision-Date: 2017-09-29 11:47+0000\n"
 "Last-Translator: Jaume  Florez Valenzuela <jflorez@gisce.net>\n"
 "Language-Team: Catalan (Spain) <erp@dev.gisce.net>\n"
 "MIME-Version: 1.0\n"
@@ -18,22 +18,9 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
-msgid ""
-" Dear ${object.partner_id.name},\n"
-"${from datetime import datetime}\n"
-"In date ${datetime.now().strftime('%d-%m-%Y %H:%M:%S')} the case has been Opened with the subject: ${upper(object.name)}\n"
-"Case Identifier: #${object.id}\n"
-"Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}\n"
-"\n"
-"            "
-msgstr " Estimat/ada ${object.partner_id.name},\n${from datetime import datetime}\nEn data ${datetime.now().strftime('%d-%m-%Y %H:%M:%S')} el cas s'ha Obert amb l'assumpte: ${upper(object.name)}\nIdentificador del Cas: #${object.id}\nResponsable: ${object.user_id.name} - ${object.user_id.address_id.email}\n\n            "
-
-#. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:111
-#, python-format
-msgid "Send"
-msgstr "Enviar"
+#: field:crm.case.rule,pm_template_id:0
+msgid "Poweremail Template"
+msgstr "Plantilla Poweremail"
 
 #. module: crm_poweremail
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close
@@ -43,9 +30,16 @@ msgid "${object.name}"
 msgstr "${object.name}"
 
 #. module: crm_poweremail
-#: view:crm.case:0
-msgid "Conversations"
-msgstr "Converses"
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_pending
+msgid ""
+"Dear ${object.partner_id.name},\n"
+"\n"
+"The case with identifier: #${object.id} with the subject: \"${object.name}\" has been updated to the state 'Pending'.\n"
+"\n"
+"Awaiting for review.\n"
+"\n"
+"            "
+msgstr "Estimat/ada ${object.partner_id.name},\n\nEl cas amb l'identificador: #${object.id} amb l'assumpte: \"${object.name}\" s'ha actualitzat al estat 'Pending'.\n\nEsperant la revisió.\n\n            "
 
 #. module: crm_poweremail
 #: field:crm.case,conversation_mails:0
@@ -58,6 +52,18 @@ msgstr "desconegut"
 msgid ""
 "Can not send mail with empty body,you should have description in the body"
 msgstr "No es pot enviar un correu amb el cos buit, hauria d'haver una descripció en el cos del missatge"
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
+msgid ""
+"Dear ${object.partner_id.name},\n"
+"\n"
+"In date ${date_now} the case has been Opened with the subject: ${object.name}\n"
+"Case Identifier: #${object.id}\n"
+"Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}\n"
+"\n"
+"            "
+msgstr "Estimat/ada ${object.partner_id.name},\n\nEn data ${date_now} s'ha Obert un cas amb l'assumpte: ${object.name}\nIdentificador del cas: #${object.id}\nResponsable: ${object.user_id.name} - ${object.user_id.address_id.email}\n\n            "
 
 #. module: crm_poweremail
 #: code:addons/crm_poweremail/crm.py:129
@@ -100,9 +106,10 @@ msgid ""
 msgstr "No s'ha trobat el ID del correu electrònic de la seva Companyia o falta el correu electrònic de resposta per aquesta secció!"
 
 #. module: crm_poweremail
-#: field:crm.case.rule,pm_template_id:0
-msgid "Poweremail Template"
-msgstr "Plantilla Poweremail"
+#: code:addons/crm_poweremail/crm.py:111
+#, python-format
+msgid "Send"
+msgstr "Enviar"
 
 #. module: crm_poweremail
 #: code:addons/crm_poweremail/crm.py:105
@@ -118,31 +125,14 @@ msgid "History"
 msgstr "Historial"
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_pending
-msgid ""
-" Dear ${object.partner_id.name},\n"
-"\n"
-"The case with identifier: #${object.id} with the subject: \"${upper(object.name)}\" has been updated to the state 'Pending'.\n"
-"\n"
-"Awaiting for review.\n"
-"\n"
-"            "
-msgstr "Estimat/ada ${object.partner_id.name},\n\nEl Cas amb indentificador: #${object.id}; amb l'assumpte: \"${upper(object.name)}\" s'ha actualitzat al estat 'Pendent'.\n\nEsperant una revisió per part del client.\n\n            "
-
-#. module: crm_poweremail
 #: model:ir.module.module,shortdesc:crm_poweremail.module_meta_information
 msgid "CRM Poweremail"
 msgstr "CRM Poweremail"
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close
-msgid ""
-" Dear ${object.partner_id.name},\n"
-"\n"
-"The case with identifier: #${object.id} with the subject: \"${upper(object.name)}\" has been CLOSED.\n"
-"\n"
-"            "
-msgstr " Estimat/ada ${object.partner_id.name},\n\nEl cas amb l'identificador: #${object.id}; amb l'assumpte: \"${upper(object.name)}\" s'ha TANCAT.\n\n            "
+#: view:crm.case:0
+msgid "Conversations"
+msgstr "Converses"
 
 #. module: crm_poweremail
 #: field:crm.case,conversation_id:0
@@ -176,3 +166,13 @@ msgid ""
 "          See: https://github.com/openlabs/poweremail/issues/24\n"
 "    "
 msgstr "\n    Aquest mòdul proveeix :\n        * Integració entre CRM i Poweremail\n        \n    NOTA: Es necessita poweremail amb suport per converses.\n          See: https://github.com/openlabs/poweremail/issues/24\n    "
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close
+msgid ""
+"Dear ${object.partner_id.name},\n"
+"\n"
+"The case with identifier: #${object.id} with the subject: \"${object.name}\" has been CLOSED.\n"
+"\n"
+"            "
+msgstr "Estimat/ada ${object.partner_id.name},\n\nEl cas amb l'identificador: #${object.id} amb l'assumpte: \"${object.name}\" s'ha TANCAT.\n\n            "

--- a/i18n/crm_poweremail.pot
+++ b/i18n/crm_poweremail.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 5.0.14\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2017-09-25 14:17\n"
-"PO-Revision-Date: 2017-09-25 14:17\n"
+"POT-Creation-Date: 2017-09-29 13:38\n"
+"PO-Revision-Date: 2017-09-29 13:38\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,20 +16,8 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
-msgid " Dear ${object.partner_id.name},\n"
-"${from datetime import datetime}\n"
-"In date ${datetime.now().strftime('%d-%m-%Y %H:%M:%S')} the case has been Opened with the subject: ${upper(object.name)}\n"
-"Case Identifier: #${object.id}\n"
-"Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}\n"
-"\n"
-"            "
-msgstr ""
-
-#. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:111
-#, python-format
-msgid "Send"
+#: field:crm.case.rule,pm_template_id:0
+msgid "Poweremail Template"
 msgstr ""
 
 #. module: crm_poweremail
@@ -40,8 +28,14 @@ msgid "${object.name}"
 msgstr ""
 
 #. module: crm_poweremail
-#: view:crm.case:0
-msgid "Conversations"
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_pending
+msgid "Dear ${object.partner_id.name},\n"
+"\n"
+"The case with identifier: #${object.id} with the subject: \"${object.name}\" has been updated to the state 'Pending'.\n"
+"\n"
+"Awaiting for review.\n"
+"\n"
+"            "
 msgstr ""
 
 #. module: crm_poweremail
@@ -53,6 +47,17 @@ msgstr ""
 #: code:addons/crm_poweremail/crm.py:109
 #, python-format
 msgid "Can not send mail with empty body,you should have description in the body"
+msgstr ""
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
+msgid "Dear ${object.partner_id.name},\n"
+"\n"
+"In date ${date_now} the case has been Opened with the subject: ${object.name}\n"
+"Case Identifier: #${object.id}\n"
+"Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}\n"
+"\n"
+"            "
 msgstr ""
 
 #. module: crm_poweremail
@@ -95,8 +100,9 @@ msgid "No E-Mail ID Found for your Company address or missing reply address in s
 msgstr ""
 
 #. module: crm_poweremail
-#: field:crm.case.rule,pm_template_id:0
-msgid "Poweremail Template"
+#: code:addons/crm_poweremail/crm.py:111
+#, python-format
+msgid "Send"
 msgstr ""
 
 #. module: crm_poweremail
@@ -111,28 +117,13 @@ msgid "History"
 msgstr ""
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_pending
-msgid " Dear ${object.partner_id.name},\n"
-"\n"
-"The case with identifier: #${object.id} with the subject: \"${upper(object.name)}\" has been updated to the state 'Pending'.\n"
-"\n"
-"Awaiting for review.\n"
-"\n"
-"            "
-msgstr ""
-
-#. module: crm_poweremail
 #: model:ir.module.module,shortdesc:crm_poweremail.module_meta_information
 msgid "CRM Poweremail"
 msgstr ""
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close
-msgid " Dear ${object.partner_id.name},\n"
-"\n"
-"The case with identifier: #${object.id} with the subject: \"${upper(object.name)}\" has been CLOSED.\n"
-"\n"
-"            "
+#: view:crm.case:0
+msgid "Conversations"
 msgstr ""
 
 #. module: crm_poweremail
@@ -165,5 +156,14 @@ msgid "\n"
 "    NOTE: Needs poweremail with conversations suport.\n"
 "          See: https://github.com/openlabs/poweremail/issues/24\n"
 "    "
+msgstr ""
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close
+msgid "Dear ${object.partner_id.name},\n"
+"\n"
+"The case with identifier: #${object.id} with the subject: \"${object.name}\" has been CLOSED.\n"
+"\n"
+"            "
 msgstr ""
 

--- a/i18n/crm_poweremail.pot
+++ b/i18n/crm_poweremail.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 5.0.14\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2017-10-05 10:02\n"
-"PO-Revision-Date: 2017-10-05 10:02\n"
+"POT-Creation-Date: 2017-10-06 11:52\n"
+"PO-Revision-Date: 2017-10-06 11:52\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -32,9 +32,27 @@ msgid "Poweremail Template"
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:220
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_new
+msgid "Dear ${object.partner_id.name},\n"
+"\n"
+"In date ${date_now} we have recieved the case with the subject: ${object.name}\n"
+"Case Identifier: #${object.id}\n"
+"\n"
+"Waiting for a responsible to take over the case.\n"
+"\n"
+"            "
+msgstr ""
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:221
 #, python-format
 msgid "Poweremail template \"Email CC\" has bad formatted address"
+msgstr ""
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/poweremail_mailbox.py:72
+#, python-format
+msgid "Reply"
 msgstr ""
 
 #. module: crm_poweremail
@@ -65,7 +83,7 @@ msgid "Can not send mail with empty body,you should have description in the body
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:129
+#: code:addons/crm_poweremail/crm.py:127
 #, python-format
 msgid "No E-Mail ID Found for your Company address!"
 msgstr ""
@@ -76,7 +94,7 @@ msgid "Invalid XML for View Architecture!"
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:212
+#: code:addons/crm_poweremail/crm.py:213
 #, python-format
 msgid "Poweremail template \"Email TO\" has bad formatted address"
 msgstr ""
@@ -101,9 +119,9 @@ msgstr ""
 #: code:addons/crm_poweremail/crm.py:101
 #: code:addons/crm_poweremail/crm.py:104
 #: code:addons/crm_poweremail/crm.py:108
-#: code:addons/crm_poweremail/crm.py:128
-#: code:addons/crm_poweremail/crm.py:212
-#: code:addons/crm_poweremail/crm.py:220
+#: code:addons/crm_poweremail/crm.py:126
+#: code:addons/crm_poweremail/crm.py:213
+#: code:addons/crm_poweremail/crm.py:221
 #, python-format
 msgid "Error!"
 msgstr ""
@@ -121,7 +139,7 @@ msgid "No E-Mail ID Found for your Company address or missing reply address in s
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:111
+#: code:addons/crm_poweremail/crm.py:129
 #, python-format
 msgid "Send"
 msgstr ""
@@ -165,6 +183,7 @@ msgstr ""
 
 #. module: crm_poweremail
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_new
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_open
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_pending
 msgid "${object.name}"

--- a/i18n/crm_poweremail.pot
+++ b/i18n/crm_poweremail.pot
@@ -6,14 +6,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 5.0.14\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2017-10-06 11:52\n"
-"PO-Revision-Date: 2017-10-06 11:52\n"
+"POT-Creation-Date: 2017-10-06 13:40\n"
+"PO-Revision-Date: 2017-10-06 13:40\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:229
+#, python-format
+msgid "Poweremail template \"Email BCC\" has bad formatted address"
+msgstr ""
 
 #. module: crm_poweremail
 #: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_pending
@@ -122,6 +128,7 @@ msgstr ""
 #: code:addons/crm_poweremail/crm.py:126
 #: code:addons/crm_poweremail/crm.py:213
 #: code:addons/crm_poweremail/crm.py:221
+#: code:addons/crm_poweremail/crm.py:229
 #, python-format
 msgid "Error!"
 msgstr ""

--- a/i18n/crm_poweremail.pot
+++ b/i18n/crm_poweremail.pot
@@ -6,26 +6,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 5.0.14\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2017-09-29 13:38\n"
-"PO-Revision-Date: 2017-09-29 13:38\n"
+"POT-Creation-Date: 2017-10-05 10:02\n"
+"PO-Revision-Date: 2017-10-05 10:02\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
-
-#. module: crm_poweremail
-#: field:crm.case.rule,pm_template_id:0
-msgid "Poweremail Template"
-msgstr ""
-
-#. module: crm_poweremail
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_open
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_pending
-msgid "${object.name}"
-msgstr ""
 
 #. module: crm_poweremail
 #: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_pending
@@ -39,14 +27,14 @@ msgid "Dear ${object.partner_id.name},\n"
 msgstr ""
 
 #. module: crm_poweremail
-#: field:crm.case,conversation_mails:0
-msgid "unknown"
+#: field:crm.case.rule,pm_template_id:0
+msgid "Poweremail Template"
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:109
+#: code:addons/crm_poweremail/crm.py:220
 #, python-format
-msgid "Can not send mail with empty body,you should have description in the body"
+msgid "Poweremail template \"Email CC\" has bad formatted address"
 msgstr ""
 
 #. module: crm_poweremail
@@ -61,6 +49,22 @@ msgid "Dear ${object.partner_id.name},\n"
 msgstr ""
 
 #. module: crm_poweremail
+#: view:crm.case:0
+msgid "Conversations"
+msgstr ""
+
+#. module: crm_poweremail
+#: field:crm.case,conversation_mails:0
+msgid "unknown"
+msgstr ""
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:109
+#, python-format
+msgid "Can not send mail with empty body,you should have description in the body"
+msgstr ""
+
+#. module: crm_poweremail
 #: code:addons/crm_poweremail/crm.py:129
 #, python-format
 msgid "No E-Mail ID Found for your Company address!"
@@ -72,8 +76,23 @@ msgid "Invalid XML for View Architecture!"
 msgstr ""
 
 #. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:212
+#, python-format
+msgid "Poweremail template \"Email TO\" has bad formatted address"
+msgstr ""
+
+#. module: crm_poweremail
 #: view:crm.case.rule:0
 msgid "E-Mail Actions"
+msgstr ""
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close
+msgid "Dear ${object.partner_id.name},\n"
+"\n"
+"The case with identifier: #${object.id} with the subject: \"${object.name}\" has been CLOSED.\n"
+"\n"
+"            "
 msgstr ""
 
 #. module: crm_poweremail
@@ -83,6 +102,8 @@ msgstr ""
 #: code:addons/crm_poweremail/crm.py:104
 #: code:addons/crm_poweremail/crm.py:108
 #: code:addons/crm_poweremail/crm.py:128
+#: code:addons/crm_poweremail/crm.py:212
+#: code:addons/crm_poweremail/crm.py:220
 #, python-format
 msgid "Error!"
 msgstr ""
@@ -122,11 +143,6 @@ msgid "CRM Poweremail"
 msgstr ""
 
 #. module: crm_poweremail
-#: view:crm.case:0
-msgid "Conversations"
-msgstr ""
-
-#. module: crm_poweremail
 #: field:crm.case,conversation_id:0
 msgid "Conversation"
 msgstr ""
@@ -148,6 +164,13 @@ msgid "You must put a Partner eMail to use this action!"
 msgstr ""
 
 #. module: crm_poweremail
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_open
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_pending
+msgid "${object.name}"
+msgstr ""
+
+#. module: crm_poweremail
 #: model:ir.module.module,description:crm_poweremail.module_meta_information
 msgid "\n"
 "    This module provide :\n"
@@ -156,14 +179,5 @@ msgid "\n"
 "    NOTE: Needs poweremail with conversations suport.\n"
 "          See: https://github.com/openlabs/poweremail/issues/24\n"
 "    "
-msgstr ""
-
-#. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close
-msgid "Dear ${object.partner_id.name},\n"
-"\n"
-"The case with identifier: #${object.id} with the subject: \"${object.name}\" has been CLOSED.\n"
-"\n"
-"            "
 msgstr ""
 

--- a/i18n/es_ES.po
+++ b/i18n/es_ES.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GISCE-ERP\n"
 "Report-Msgid-Bugs-To: https://github.com/gisce/erp/issues\n"
-"POT-Creation-Date: 2017-09-29 13:38\n"
-"PO-Revision-Date: 2017-09-29 11:42+0000\n"
+"POT-Creation-Date: 2017-10-05 10:02\n"
+"PO-Revision-Date: 2017-10-05 08:09+0000\n"
 "Last-Translator: Jaume  Florez Valenzuela <jflorez@gisce.net>\n"
 "Language-Team: Spanish (Spain) <erp@dev.gisce.net>\n"
 "MIME-Version: 1.0\n"
@@ -16,18 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Language: es_ES\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
-#. module: crm_poweremail
-#: field:crm.case.rule,pm_template_id:0
-msgid "Poweremail Template"
-msgstr "Plantilla Poweremail"
-
-#. module: crm_poweremail
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_open
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_pending
-msgid "${object.name}"
-msgstr "${object.name}"
 
 #. module: crm_poweremail
 #: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_pending
@@ -39,7 +27,35 @@ msgid ""
 "Awaiting for review.\n"
 "\n"
 "            "
-msgstr "Estimado/da ${object.partner_id.name},\n\nEl caso con identificador: #${object.id} con el asunto: \\\"${object.name}\\\"; ha pasado al estado: 'Pending'.\n\nEsperando revisión.    "
+msgstr "Estimado/da ${object.partner_id.name},\n\nEl caso con identificador: #${object.id} con el asunto: \"${object.name}\"; ha pasado al estado: 'Pending'.\n\nEsperando revisión.\n\n      "
+
+#. module: crm_poweremail
+#: field:crm.case.rule,pm_template_id:0
+msgid "Poweremail Template"
+msgstr "Plantilla Poweremail"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:220
+#, python-format
+msgid "Poweremail template \"Email CC\" has bad formatted address"
+msgstr "La dirección \"CC\" de la plantilla Power E-mail no tiene un formato correcto"
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
+msgid ""
+"Dear ${object.partner_id.name},\n"
+"\n"
+"In date ${date_now} the case has been Opened with the subject: ${object.name}\n"
+"Case Identifier: #${object.id}\n"
+"Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}\n"
+"\n"
+"            "
+msgstr "Estimado/da ${object.partner_id.name},\n\nEn fecha ${date_now} el caso se ha Abierto con el asunto: ${object.name}\n\nIdentificador del Caso: #${object.id}\nResponsable: ${object.user_id.name} - {object.user_id.address_id.email}\n\n       "
+
+#. module: crm_poweremail
+#: view:crm.case:0
+msgid "Conversations"
+msgstr "Conversaciones"
 
 #. module: crm_poweremail
 #: field:crm.case,conversation_mails:0
@@ -54,18 +70,6 @@ msgid ""
 msgstr "No se puede enviar un correo sin cuerpo, debería haber una descripción en el cuerpo"
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
-msgid ""
-"Dear ${object.partner_id.name},\n"
-"\n"
-"In date ${date_now} the case has been Opened with the subject: ${object.name}\n"
-"Case Identifier: #${object.id}\n"
-"Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}\n"
-"\n"
-"            "
-msgstr "Estimado/da ${object.partner_id.name},\n\nEn fecha ${date_now} el caso se ha Abierto con el asunto: ${object.name}\nIdentificador del Caso: #${object.id}\nResponsable: ${object.user_id.name} - {object.user_id.address_id.email}\n "
-
-#. module: crm_poweremail
 #: code:addons/crm_poweremail/crm.py:129
 #, python-format
 msgid "No E-Mail ID Found for your Company address!"
@@ -77,14 +81,31 @@ msgid "Invalid XML for View Architecture!"
 msgstr "Arquitectura de XML inválida"
 
 #. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:212
+#, python-format
+msgid "Poweremail template \"Email TO\" has bad formatted address"
+msgstr "La dirección \"TO\" de la plantilla Power E-mail no tiene un formato correcto"
+
+#. module: crm_poweremail
 #: view:crm.case.rule:0
 msgid "E-Mail Actions"
 msgstr "Acciones de Correo Electrónico"
 
 #. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close
+msgid ""
+"Dear ${object.partner_id.name},\n"
+"\n"
+"The case with identifier: #${object.id} with the subject: \"${object.name}\" has been CLOSED.\n"
+"\n"
+"            "
+msgstr "Estimado/da ${object.partner_id.name},\n\nEl caso con el identificador: #${object.id}; con el asunto: \"${object.name}\" se ha CERRADO.\n\n    "
+
+#. module: crm_poweremail
 #: code:addons/crm_poweremail/crm.py:60 code:addons/crm_poweremail/crm.py:67
 #: code:addons/crm_poweremail/crm.py:101 code:addons/crm_poweremail/crm.py:104
 #: code:addons/crm_poweremail/crm.py:108 code:addons/crm_poweremail/crm.py:128
+#: code:addons/crm_poweremail/crm.py:212 code:addons/crm_poweremail/crm.py:220
 #, python-format
 msgid "Error!"
 msgstr "Error!"
@@ -130,11 +151,6 @@ msgid "CRM Poweremail"
 msgstr "CRM Poweremail"
 
 #. module: crm_poweremail
-#: view:crm.case:0
-msgid "Conversations"
-msgstr "Conversaciones"
-
-#. module: crm_poweremail
 #: field:crm.case,conversation_id:0
 msgid "Conversation"
 msgstr "Conversación"
@@ -156,6 +172,13 @@ msgid "You must put a Partner eMail to use this action!"
 msgstr "Se debe facilitar la dirección de correo electrónico de la Empresa para utilitzar esta acción!"
 
 #. module: crm_poweremail
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_open
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_pending
+msgid "${object.name}"
+msgstr "${object.name}"
+
+#. module: crm_poweremail
 #: model:ir.module.module,description:crm_poweremail.module_meta_information
 msgid ""
 "\n"
@@ -166,13 +189,3 @@ msgid ""
 "          See: https://github.com/openlabs/poweremail/issues/24\n"
 "    "
 msgstr "\n    Este módulo provee:\n        * Integración entre CRM y Poweremail\n        \n    NOTA: Se necesita poweremail con soporte para conversaciones.\n          Ver: https://github.com/openlabs/poweremail/issues/24\n    "
-
-#. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close
-msgid ""
-"Dear ${object.partner_id.name},\n"
-"\n"
-"The case with identifier: #${object.id} with the subject: \"${object.name}\" has been CLOSED.\n"
-"\n"
-"            "
-msgstr "Estimado/da ${object.partner_id.name},\n\nEl caso con el identificador: #${object.id}; con el asunto: \\\"${object.name}\\\" se ha CERRADO.\n "

--- a/i18n/es_ES.po
+++ b/i18n/es_ES.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GISCE-ERP\n"
 "Report-Msgid-Bugs-To: https://github.com/gisce/erp/issues\n"
-"POT-Creation-Date: 2017-10-05 10:02\n"
-"PO-Revision-Date: 2017-10-05 08:09+0000\n"
+"POT-Creation-Date: 2017-10-06 11:52\n"
+"PO-Revision-Date: 2017-10-06 09:58+0000\n"
 "Last-Translator: Jaume  Florez Valenzuela <jflorez@gisce.net>\n"
 "Language-Team: Spanish (Spain) <erp@dev.gisce.net>\n"
 "MIME-Version: 1.0\n"
@@ -27,7 +27,7 @@ msgid ""
 "Awaiting for review.\n"
 "\n"
 "            "
-msgstr "Estimado/da ${object.partner_id.name},\n\nEl caso con identificador: #${object.id} con el asunto: \"${object.name}\"; ha pasado al estado: 'Pending'.\n\nEsperando revisión.\n\n      "
+msgstr "Estimado/da ${object.partner_id.name},\n\nEl caso con identificador: #${object.id} con el asunto: \"${object.name}\"; ha pasado al estado: 'Pending'.\n\nEsperando revisión."
 
 #. module: crm_poweremail
 #: field:crm.case.rule,pm_template_id:0
@@ -35,10 +35,29 @@ msgid "Poweremail Template"
 msgstr "Plantilla Poweremail"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:220
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_new
+msgid ""
+"Dear ${object.partner_id.name},\n"
+"\n"
+"In date ${date_now} we have recieved the case with the subject: ${object.name}\n"
+"Case Identifier: #${object.id}\n"
+"\n"
+"Waiting for a responsible to take over the case.\n"
+"\n"
+"            "
+msgstr "Estimado/da ${object.partner_id.name},\n\nEn fecha ${date_now} hemos recibido un caso con el asunto: ${object.name}\n\nIdentificador del Caso: #${object.id}\n\nEsperando la asignación de un responsable.\n\n             \n\n      "
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:221
 #, python-format
 msgid "Poweremail template \"Email CC\" has bad formatted address"
 msgstr "La dirección \"CC\" de la plantilla Power E-mail no tiene un formato correcto"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/poweremail_mailbox.py:72
+#, python-format
+msgid "Reply"
+msgstr "Resposta"
 
 #. module: crm_poweremail
 #: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
@@ -70,7 +89,7 @@ msgid ""
 msgstr "No se puede enviar un correo sin cuerpo, debería haber una descripción en el cuerpo"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:129
+#: code:addons/crm_poweremail/crm.py:127
 #, python-format
 msgid "No E-Mail ID Found for your Company address!"
 msgstr "No se ha encontrado un ID de correo electrónico para la dirección de su Compañía!"
@@ -81,7 +100,7 @@ msgid "Invalid XML for View Architecture!"
 msgstr "Arquitectura de XML inválida"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:212
+#: code:addons/crm_poweremail/crm.py:213
 #, python-format
 msgid "Poweremail template \"Email TO\" has bad formatted address"
 msgstr "La dirección \"TO\" de la plantilla Power E-mail no tiene un formato correcto"
@@ -104,8 +123,8 @@ msgstr "Estimado/da ${object.partner_id.name},\n\nEl caso con el identificador: 
 #. module: crm_poweremail
 #: code:addons/crm_poweremail/crm.py:60 code:addons/crm_poweremail/crm.py:67
 #: code:addons/crm_poweremail/crm.py:101 code:addons/crm_poweremail/crm.py:104
-#: code:addons/crm_poweremail/crm.py:108 code:addons/crm_poweremail/crm.py:128
-#: code:addons/crm_poweremail/crm.py:212 code:addons/crm_poweremail/crm.py:220
+#: code:addons/crm_poweremail/crm.py:108 code:addons/crm_poweremail/crm.py:126
+#: code:addons/crm_poweremail/crm.py:213 code:addons/crm_poweremail/crm.py:221
 #, python-format
 msgid "Error!"
 msgstr "Error!"
@@ -127,7 +146,7 @@ msgid ""
 msgstr "No se ha encontrado el ID de correo electrónico para la dirección de su Compañía o en la dirección de resupesta de esta sección!"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:111
+#: code:addons/crm_poweremail/crm.py:129
 #, python-format
 msgid "Send"
 msgstr "Enviar"
@@ -173,6 +192,7 @@ msgstr "Se debe facilitar la dirección de correo electrónico de la Empresa par
 
 #. module: crm_poweremail
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_new
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_open
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_pending
 msgid "${object.name}"

--- a/i18n/es_ES.po
+++ b/i18n/es_ES.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GISCE-ERP\n"
 "Report-Msgid-Bugs-To: https://github.com/gisce/erp/issues\n"
-"POT-Creation-Date: 2017-10-06 11:52\n"
-"PO-Revision-Date: 2017-10-06 09:58+0000\n"
+"POT-Creation-Date: 2017-10-06 13:40\n"
+"PO-Revision-Date: 2017-10-06 11:41+0000\n"
 "Last-Translator: Jaume  Florez Valenzuela <jflorez@gisce.net>\n"
 "Language-Team: Spanish (Spain) <erp@dev.gisce.net>\n"
 "MIME-Version: 1.0\n"
@@ -16,6 +16,12 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Language: es_ES\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:229
+#, python-format
+msgid "Poweremail template \"Email BCC\" has bad formatted address"
+msgstr "La dirección \"BCC\" de la plantilla Power E-mail no tiene un formato correcto"
 
 #. module: crm_poweremail
 #: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_pending
@@ -125,6 +131,7 @@ msgstr "Estimado/da ${object.partner_id.name},\n\nEl caso con el identificador: 
 #: code:addons/crm_poweremail/crm.py:101 code:addons/crm_poweremail/crm.py:104
 #: code:addons/crm_poweremail/crm.py:108 code:addons/crm_poweremail/crm.py:126
 #: code:addons/crm_poweremail/crm.py:213 code:addons/crm_poweremail/crm.py:221
+#: code:addons/crm_poweremail/crm.py:229
 #, python-format
 msgid "Error!"
 msgstr "Error!"

--- a/i18n/es_ES.po
+++ b/i18n/es_ES.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GISCE-ERP\n"
 "Report-Msgid-Bugs-To: https://github.com/gisce/erp/issues\n"
-"POT-Creation-Date: 2017-09-25 14:17\n"
-"PO-Revision-Date: 2017-09-25 12:48+0000\n"
+"POT-Creation-Date: 2017-09-29 13:38\n"
+"PO-Revision-Date: 2017-09-29 11:42+0000\n"
 "Last-Translator: Jaume  Florez Valenzuela <jflorez@gisce.net>\n"
 "Language-Team: Spanish (Spain) <erp@dev.gisce.net>\n"
 "MIME-Version: 1.0\n"
@@ -18,22 +18,9 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
-msgid ""
-" Dear ${object.partner_id.name},\n"
-"${from datetime import datetime}\n"
-"In date ${datetime.now().strftime('%d-%m-%Y %H:%M:%S')} the case has been Opened with the subject: ${upper(object.name)}\n"
-"Case Identifier: #${object.id}\n"
-"Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}\n"
-"\n"
-"            "
-msgstr " Estimado/da ${object.partner_id.name},\n${from datetime import datetime}\nEn fecha ${datetime.now().strftime('%d-%m-%Y %H:%M:%S')} el caso se ha Abierto con el asunto: ${upper(object.name)}\nIdentificador del Caso: #${object.id}\nResponsable: ${object.user_id.name} - ${object.user_id.address_id.email}\n\n            "
-
-#. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:111
-#, python-format
-msgid "Send"
-msgstr "Enviar"
+#: field:crm.case.rule,pm_template_id:0
+msgid "Poweremail Template"
+msgstr "Plantilla Poweremail"
 
 #. module: crm_poweremail
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close
@@ -43,9 +30,16 @@ msgid "${object.name}"
 msgstr "${object.name}"
 
 #. module: crm_poweremail
-#: view:crm.case:0
-msgid "Conversations"
-msgstr "Conversaciones"
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_pending
+msgid ""
+"Dear ${object.partner_id.name},\n"
+"\n"
+"The case with identifier: #${object.id} with the subject: \"${object.name}\" has been updated to the state 'Pending'.\n"
+"\n"
+"Awaiting for review.\n"
+"\n"
+"            "
+msgstr "Estimado/da ${object.partner_id.name},\n\nEl caso con identificador: #${object.id} con el asunto: \\\"${object.name}\\\"; ha pasado al estado: 'Pending'.\n\nEsperando revisión.    "
 
 #. module: crm_poweremail
 #: field:crm.case,conversation_mails:0
@@ -58,6 +52,18 @@ msgstr "desconocido"
 msgid ""
 "Can not send mail with empty body,you should have description in the body"
 msgstr "No se puede enviar un correo sin cuerpo, debería haber una descripción en el cuerpo"
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
+msgid ""
+"Dear ${object.partner_id.name},\n"
+"\n"
+"In date ${date_now} the case has been Opened with the subject: ${object.name}\n"
+"Case Identifier: #${object.id}\n"
+"Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}\n"
+"\n"
+"            "
+msgstr "Estimado/da ${object.partner_id.name},\n\nEn fecha ${date_now} el caso se ha Abierto con el asunto: ${object.name}\nIdentificador del Caso: #${object.id}\nResponsable: ${object.user_id.name} - {object.user_id.address_id.email}\n "
 
 #. module: crm_poweremail
 #: code:addons/crm_poweremail/crm.py:129
@@ -100,9 +106,10 @@ msgid ""
 msgstr "No se ha encontrado el ID de correo electrónico para la dirección de su Compañía o en la dirección de resupesta de esta sección!"
 
 #. module: crm_poweremail
-#: field:crm.case.rule,pm_template_id:0
-msgid "Poweremail Template"
-msgstr "Plantilla Poweremail"
+#: code:addons/crm_poweremail/crm.py:111
+#, python-format
+msgid "Send"
+msgstr "Enviar"
 
 #. module: crm_poweremail
 #: code:addons/crm_poweremail/crm.py:105
@@ -118,31 +125,14 @@ msgid "History"
 msgstr "Historial"
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_pending
-msgid ""
-" Dear ${object.partner_id.name},\n"
-"\n"
-"The case with identifier: #${object.id} with the subject: \"${upper(object.name)}\" has been updated to the state 'Pending'.\n"
-"\n"
-"Awaiting for review.\n"
-"\n"
-"            "
-msgstr " Estimado/da ${object.partner_id.name},\n\nEl caso con identificador: #${object.id} con el asunto: \"${upper(object.name)}\"; ha pasado al estado: 'Pending'.\n\nEsperando revisión.\n\n            "
-
-#. module: crm_poweremail
 #: model:ir.module.module,shortdesc:crm_poweremail.module_meta_information
 msgid "CRM Poweremail"
 msgstr "CRM Poweremail"
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close
-msgid ""
-" Dear ${object.partner_id.name},\n"
-"\n"
-"The case with identifier: #${object.id} with the subject: \"${upper(object.name)}\" has been CLOSED.\n"
-"\n"
-"            "
-msgstr " Estimado/da ${object.partner_id.name},\n\nEl caso con el identificador: #${object.id}; con el asunto: \"${upper(object.name)}\" se ha CERRADO.\n\n            "
+#: view:crm.case:0
+msgid "Conversations"
+msgstr "Conversaciones"
 
 #. module: crm_poweremail
 #: field:crm.case,conversation_id:0
@@ -176,3 +166,13 @@ msgid ""
 "          See: https://github.com/openlabs/poweremail/issues/24\n"
 "    "
 msgstr "\n    Este módulo provee:\n        * Integración entre CRM y Poweremail\n        \n    NOTA: Se necesita poweremail con soporte para conversaciones.\n          Ver: https://github.com/openlabs/poweremail/issues/24\n    "
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close
+msgid ""
+"Dear ${object.partner_id.name},\n"
+"\n"
+"The case with identifier: #${object.id} with the subject: \"${object.name}\" has been CLOSED.\n"
+"\n"
+"            "
+msgstr "Estimado/da ${object.partner_id.name},\n\nEl caso con el identificador: #${object.id}; con el asunto: \\\"${object.name}\\\" se ha CERRADO.\n "

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
 from osv import osv
 from tools.translate import _
+from talon import quotations
 
 import qreu
+import talon
+
+talon.init()
 
 
 class PoweremailMailboxCRM(osv.osv):
@@ -35,6 +39,7 @@ class PoweremailMailboxCRM(osv.osv):
             # p_mail.complete_mail()
             # Fuck re-browse to get the content
             p_mail = self.browse(cursor, uid, res_id, context=context)
+            body_text = quotations.extract_from_plain(p_mail.pem_body_text)
             section_id = section_id[0]
             case_id = case_obj.search(cursor, uid, [
                 ('conversation_id', '=', p_mail.conversation_id.id)
@@ -49,7 +54,7 @@ class PoweremailMailboxCRM(osv.osv):
                     'conversation_id': p_mail.conversation_id.id,
                     'name': p_mail.pem_subject,
                     'section_id': section_id,
-                    'description': p_mail.pem_body_text,
+                    'description': body_text,
                     'email_from': p_mail.pem_from,
                     'email_cc': p_mail.pem_cc,
                     'user_id': section.user_id and section.user_id.id,
@@ -63,7 +68,7 @@ class PoweremailMailboxCRM(osv.osv):
                 case_obj.create(cursor, uid, case_vals)
             else:
                 case_obj.write(cursor, uid, case_id, {
-                    'description': p_mail.pem_body_text
+                    'description': body_text
                 })
                 cases = case_obj.browse(cursor, uid, case_id)
                 case_obj._history(

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 from osv import osv
+from tools.translate import _
+
 import qreu
 
 
@@ -59,6 +61,15 @@ class PoweremailMailboxCRM(osv.osv):
                         'partner_id': address.partner_id.id
                     })
                 case_obj.create(cursor, uid, case_vals)
+            else:
+                case_obj.write(cursor, uid, case_id, {
+                    'description': p_mail.pem_body_text
+                })
+                cases = case_obj.browse(cursor, uid, case_id)
+                case_obj._history(
+                    cursor, uid, cases, _('Reply'), history=True,
+                    email=mail.from_.address
+                )
         return res_id
  
 PoweremailMailboxCRM()

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -4,9 +4,6 @@ from tools.translate import _
 from talon import quotations
 
 import qreu
-import talon
-
-talon.init()
 
 
 class PoweremailMailboxCRM(osv.osv):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Mako
+talon


### PR DESCRIPTION
Related to [OpenERP/5337](https://github.com/gisce/erp/pull/5337), adding get_addresses method:

- Incluede e-mail addresses from poweremail_template related to crm.case.rule

Also fix some bugs on poweremail templates

- [x] translate the poweremail templates using template lang
- [x] correctly parse the template lang before translating
- [x] Add description to history log on open
- [x] Add answers to history log
- [x] ~Remove signatures on history log~ → Maybe a future implementation with rq can do it
- [x] Remove replies on history log answers