### PR TITLE
Fix poweremail templates

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 import crm
+import res_partner
 import poweremail_mailbox

--- a/__terp__.py
+++ b/__terp__.py
@@ -12,7 +12,7 @@
           See: https://github.com/openlabs/poweremail/issues/24
     """,
     "init_xml": [],
-    'update_xml': ['crm_view.xml', 'crm_data.xml'],
+    'update_xml': ['crm_view.xml', 'crm_data.xml', 'res_partner_view.xml'],
     'demo_xml': [],
     'installable': True,
     'active': False,

--- a/crm.py
+++ b/crm.py
@@ -70,6 +70,8 @@ class CrmCase(osv.osv):
         email_cc = context.get('email_cc', [])
         email_cc.append(reply_to)
         # TODO: Improve reply-to finding in conversation
+        if '' in email_cc:
+            email_cc.remove('')
         pm_mailbox_obj.create(cursor, uid, {
             'pem_from': emailfrom,
             'pem_to': ', '.join(set(emails)),

--- a/crm_data.xml
+++ b/crm_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
-    <data>
+    <data noupdate="1">
         <!-- CRM Poweremail - Templates -->
         <record model="poweremail.templates" id="crm_poweremail_case_template_new">
             <field name="name">New Case Template</field>

--- a/crm_data.xml
+++ b/crm_data.xml
@@ -79,7 +79,6 @@ The case with identifier: #${object.id} with the subject: "${object.name}" has b
             <field name="name">Poweremail New Case</field>
             <field name="active">True</field>
             <field name="trg_state_from">draft</field>
-            <field name="trg_date_type">create</field>
             <field name="trg_max_history" eval="0"/>
             <field name="trg_limit_history" eval="1"/>
             <field name="pm_template_id" ref="crm_poweremail_case_template_new"/>
@@ -90,7 +89,10 @@ The case with identifier: #${object.id} with the subject: "${object.name}" has b
             <field name="active">True</field>
             <field name="trg_state_from">draft</field>
             <field name="trg_state_to">open</field>
+            <field name="trg_max_history" eval="0"/>
+            <field name="trg_limit_history" eval="2"/>
             <field name="pm_template_id" ref="crm_poweremail_case_template_open"/>
+            <field name="act_mail_to_email" eval=""/>
             <field name="act_mail_to_user" eval="True"/>
             <field name="act_mail_to_partner" eval="True"/>
         </record>
@@ -101,6 +103,7 @@ The case with identifier: #${object.id} with the subject: "${object.name}" has b
             <field name="trg_state_from">open</field>
             <field name="trg_state_to">pending</field>
             <field name="pm_template_id" ref="crm_poweremail_case_template_pending"/>
+            <field name="act_mail_to_email" eval=""/>
             <field name="act_mail_to_user" eval="True"/>
             <field name="act_mail_to_partner" eval="True"/>
         </record>
@@ -111,6 +114,7 @@ The case with identifier: #${object.id} with the subject: "${object.name}" has b
             <field name="trg_state_from">pending</field>
             <field name="trg_state_to">done</field>
             <field name="pm_template_id" ref="crm_poweremail_case_template_close"/>
+            <field name="act_mail_to_email" eval=""/>
             <field name="act_mail_to_user" eval="True"/>
             <field name="act_mail_to_partner" eval="True"/>
         </record>

--- a/crm_data.xml
+++ b/crm_data.xml
@@ -12,7 +12,7 @@
             <field name="template_language">mako</field>
             <field name="use_sign" eval="False"/>
             <field name="lang" eval="False"/>
-            <field name="def_body_text">Dear ${object.partner_id.name},
+            <field name="def_body_text">Hi there,
 
 In date ${date_now} we have recieved the case with the subject: ${object.name}
 Case Identifier: #${object.id}
@@ -31,11 +31,12 @@ Waiting for a responsible to take over the case.
             <field name="lang" >${object.partner_id.lang}</field>
             <field name="template_language">mako</field>
             <field name="use_sign" eval="False"/>
-            <field name="def_body_text">Dear ${object.partner_id.name},
+            <field name="def_body_text">Hi there,
 
 In date ${date_now} the case has been Opened with the subject: ${object.name}
 Case Identifier: #${object.id}
-Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}
+
+Responsible: ${object.user_id.name} &lt;${object.user_id.address_id.email}&gt;
 
             </field>
         </record>
@@ -49,7 +50,7 @@ Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}
             <field name="lang" >${object.partner_id.lang}</field>
             <field name="template_language">mako</field>
             <field name="use_sign" eval="False"/>
-            <field name="def_body_text">Dear ${object.partner_id.name},
+            <field name="def_body_text">Hi there,
 
 The case with identifier: #${object.id} with the subject: "${object.name}" has been updated to the state 'Pending'.
 
@@ -67,7 +68,7 @@ Awaiting for review.
             <field name="lang" >${object.partner_id.lang}</field>
             <field name="template_language">mako</field>
             <field name="use_sign" eval="False"/>
-            <field name="def_body_text">Dear ${object.partner_id.name},
+            <field name="def_body_text">Hi there,
 
 The case with identifier: #${object.id} with the subject: "${object.name}" has been CLOSED.
 

--- a/crm_data.xml
+++ b/crm_data.xml
@@ -12,7 +12,6 @@
             <field name="template_language">mako</field>
             <field name="use_sign" eval="False"/>
             <field name="lang" eval="False"/>
-            <field name="save_to_drafts" eval="True"/>
             <field name="def_body_text">Dear ${object.partner_id.name},
 
 In date ${date_now} we have recieved the case with the subject: ${object.name}
@@ -32,7 +31,6 @@ Waiting for a responsible to take over the case.
             <field name="lang" >${object.partner_id.lang}</field>
             <field name="template_language">mako</field>
             <field name="use_sign" eval="False"/>
-            <field name="save_to_drafts" eval="True"/>
             <field name="def_body_text">Dear ${object.partner_id.name},
 
 In date ${date_now} the case has been Opened with the subject: ${object.name}
@@ -51,7 +49,6 @@ Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}
             <field name="lang" >${object.partner_id.lang}</field>
             <field name="template_language">mako</field>
             <field name="use_sign" eval="False"/>
-            <field name="save_to_drafts" eval="True"/>
             <field name="def_body_text">Dear ${object.partner_id.name},
 
 The case with identifier: #${object.id} with the subject: "${object.name}" has been updated to the state 'Pending'.
@@ -70,7 +67,6 @@ Awaiting for review.
             <field name="lang" >${object.partner_id.lang}</field>
             <field name="template_language">mako</field>
             <field name="use_sign" eval="False"/>
-            <field name="save_to_drafts" eval="True"/>
             <field name="def_body_text">Dear ${object.partner_id.name},
 
 The case with identifier: #${object.id} with the subject: "${object.name}" has been CLOSED.

--- a/i18n/ca_ES.po
+++ b/i18n/ca_ES.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GISCE-ERP\n"
 "Report-Msgid-Bugs-To: https://github.com/gisce/erp/issues\n"
-"POT-Creation-Date: 2017-10-06 13:40\n"
-"PO-Revision-Date: 2017-10-06 11:42+0000\n"
+"POT-Creation-Date: 2017-11-02 17:07\n"
+"PO-Revision-Date: 2017-11-02 16:34+0000\n"
 "Last-Translator: Jaume  Florez Valenzuela <jflorez@gisce.net>\n"
 "Language-Team: Catalan (Spain) <erp@dev.gisce.net>\n"
 "MIME-Version: 1.0\n"
@@ -18,22 +18,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:229
+#: field:res.partner,domain:0
+msgid "Email domain"
+msgstr "Domini de Correu"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:207
 #, python-format
 msgid "Poweremail template \"Email BCC\" has bad formatted address"
 msgstr "La direcció \"BCC\" de la plantilla Power E-mail no té un format correcte"
-
-#. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_pending
-msgid ""
-"Dear ${object.partner_id.name},\n"
-"\n"
-"The case with identifier: #${object.id} with the subject: \"${object.name}\" has been updated to the state 'Pending'.\n"
-"\n"
-"Awaiting for review.\n"
-"\n"
-"            "
-msgstr "Estimat/ada ${object.partner_id.name},\n\nEl cas amb l'identificador: #${object.id} amb l'assumpte: \"${object.name}\" s'ha actualitzat al estat 'Pending'.\n\nEsperant la revisió.\n\n            "
 
 #. module: crm_poweremail
 #: field:crm.case.rule,pm_template_id:0
@@ -41,41 +34,19 @@ msgid "Poweremail Template"
 msgstr "Plantilla Poweremail"
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_new
-msgid ""
-"Dear ${object.partner_id.name},\n"
-"\n"
-"In date ${date_now} we have recieved the case with the subject: ${object.name}\n"
-"Case Identifier: #${object.id}\n"
-"\n"
-"Waiting for a responsible to take over the case.\n"
-"\n"
-"            "
-msgstr "Estimat/ada ${object.partner_id.name},\n\nEn data ${date_now} s'ha rebut un cas amb l'assumpte: ${object.name}\n\nIdentificador del cas: #${object.id}\n\nEsperant l'assignació d'un responsable.\n\n            "
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_new
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_open
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_pending
+msgid "${object.name}"
+msgstr "${object.name}"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:221
-#, python-format
-msgid "Poweremail template \"Email CC\" has bad formatted address"
-msgstr "La direcció \"CC\" de la plantilla Power E-mail no té un format correcte"
-
-#. module: crm_poweremail
-#: code:addons/crm_poweremail/poweremail_mailbox.py:72
+#: code:addons/crm_poweremail/poweremail_mailbox.py:158
+#: code:addons/crm_poweremail/poweremail_mailbox.py:167
 #, python-format
 msgid "Reply"
 msgstr "Resposta"
-
-#. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
-msgid ""
-"Dear ${object.partner_id.name},\n"
-"\n"
-"In date ${date_now} the case has been Opened with the subject: ${object.name}\n"
-"Case Identifier: #${object.id}\n"
-"Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}\n"
-"\n"
-"            "
-msgstr "Estimat/ada ${object.partner_id.name},\n\nEn data ${date_now} s'ha Obert un cas amb l'assumpte: ${object.name}\n\nIdentificador del cas: #${object.id}\nResponsable: ${object.user_id.name} - ${object.user_id.address_id.email}\n\n            "
 
 #. module: crm_poweremail
 #: view:crm.case:0
@@ -88,30 +59,6 @@ msgid "unknown"
 msgstr "desconegut"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:109
-#, python-format
-msgid ""
-"Can not send mail with empty body,you should have description in the body"
-msgstr "No es pot enviar un correu amb el cos buit, hauria d'haver una descripció en el cos del missatge"
-
-#. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:127
-#, python-format
-msgid "No E-Mail ID Found for your Company address!"
-msgstr "No s'ha trobat la ID del correu electrònic de la direcció de la seva Companyia"
-
-#. module: crm_poweremail
-#: constraint:ir.ui.view:0
-msgid "Invalid XML for View Architecture!"
-msgstr "Arquitectura del XML invàlida!"
-
-#. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:213
-#, python-format
-msgid "Poweremail template \"Email TO\" has bad formatted address"
-msgstr "La direcció \"TO\" de la plantilla Power E-mail no té un format correcte"
-
-#. module: crm_poweremail
 #: view:crm.case.rule:0
 msgid "E-Mail Actions"
 msgstr "Accions de correu electrònic"
@@ -119,19 +66,75 @@ msgstr "Accions de correu electrònic"
 #. module: crm_poweremail
 #: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close
 msgid ""
-"Dear ${object.partner_id.name},\n"
+"Hi there,\n"
 "\n"
 "The case with identifier: #${object.id} with the subject: \"${object.name}\" has been CLOSED.\n"
 "\n"
 "            "
-msgstr "Estimat/ada ${object.partner_id.name},\n\nEl cas amb l'identificador: #${object.id} amb l'assumpte: \"${object.name}\" s'ha TANCAT.\n\n            "
+msgstr "Bon dia,\n\nEl cas amb l'identificador: #${object.id} amb l'assumpte: \"${object.name}\" s'ha TANCAT.\n\n            "
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
+msgid ""
+"Hi there,\n"
+"\n"
+"In date ${date_now} the case has been Opened with the subject: ${object.name}\n"
+"Case Identifier: #${object.id}\n"
+"\n"
+"Responsible: ${object.user_id.name} <${object.user_id.address_id.email}>\n"
+"\n"
+"            "
+msgstr "Bon dia,\n\nEn data ${date_now} s'ha Obert un cas amb l'assumpte: ${object.name}\n\nIdentificador del cas: #${object.id}\n\nResponsable: ${object.user_id.name} <${object.user_id.address_id.email}>\n\n            "
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:131
+#, python-format
+msgid "No E-Mail ID Found for your Company address!"
+msgstr "No s'ha trobat la ID del correu electrònic de la direcció de la seva Companyia"
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_new
+msgid ""
+"Hi there,\n"
+"\n"
+"In date ${date_now} we have recieved the case with the subject: ${object.name}\n"
+"Case Identifier: #${object.id}\n"
+"\n"
+"Waiting for a responsible to take over the case.\n"
+"\n"
+"            "
+msgstr "Bon dia,\n\nEn data ${date_now} s'ha rebut un cas amb l'assumpte: ${object.name}\n\nIdentificador del cas: #${object.id}\n\nEsperant l'assignació d'un responsable.\n\n            "
+
+#. module: crm_poweremail
+#: constraint:ir.ui.view:0
+msgid "Invalid XML for View Architecture!"
+msgstr "Arquitectura del XML invàlida!"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/poweremail_mailbox.py:41
+#, python-format
+msgid "Could not parse poweremail_mailbox pem_from address with qreu"
+msgstr "No es pot tractar l'adreça \"pem_from\" del correu de poweremail amb \"qreu\""
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:189
+#, python-format
+msgid "Poweremail template \"Email TO\" has bad formatted address"
+msgstr "La direcció \"TO\" de la plantilla Power E-mail no té un format correcte"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:113
+#, python-format
+msgid ""
+"Can not send mail with empty body,you should have description in the body"
+msgstr "No es pot enviar un correu amb el cos buit, hauria d'haver una descripció en el cos del missatge"
 
 #. module: crm_poweremail
 #: code:addons/crm_poweremail/crm.py:60 code:addons/crm_poweremail/crm.py:67
-#: code:addons/crm_poweremail/crm.py:101 code:addons/crm_poweremail/crm.py:104
-#: code:addons/crm_poweremail/crm.py:108 code:addons/crm_poweremail/crm.py:126
-#: code:addons/crm_poweremail/crm.py:213 code:addons/crm_poweremail/crm.py:221
-#: code:addons/crm_poweremail/crm.py:229
+#: code:addons/crm_poweremail/crm.py:105 code:addons/crm_poweremail/crm.py:108
+#: code:addons/crm_poweremail/crm.py:112 code:addons/crm_poweremail/crm.py:130
+#: code:addons/crm_poweremail/crm.py:189 code:addons/crm_poweremail/crm.py:197
+#: code:addons/crm_poweremail/crm.py:207
 #, python-format
 msgid "Error!"
 msgstr "Error!"
@@ -153,13 +156,13 @@ msgid ""
 msgstr "No s'ha trobat el ID del correu electrònic de la seva Companyia o falta el correu electrònic de resposta per aquesta secció!"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:129
+#: code:addons/crm_poweremail/crm.py:133
 #, python-format
 msgid "Send"
 msgstr "Enviar"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:105
+#: code:addons/crm_poweremail/crm.py:109
 #, python-format
 msgid ""
 "You must define a responsible user for this case in order to use this "
@@ -192,18 +195,28 @@ msgid "PowerEmail Template"
 msgstr "Plantilla PowerEmail"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:102
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_pending
+msgid ""
+"Hi there,\n"
+"\n"
+"The case with identifier: #${object.id} with the subject: \"${object.name}\" has been updated to the state 'Pending'.\n"
+"\n"
+"Awaiting for review.\n"
+"\n"
+"            "
+msgstr "Bon dia,\n\nEl cas amb l'identificador: #${object.id} amb l'assumpte: \"${object.name}\" s'ha actualitzat al estat 'Pendent'.\n\nEsperant la revisió.\n\n            "
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:106
 #, python-format
 msgid "You must put a Partner eMail to use this action!"
 msgstr "S'ha d'introduïr el correu electrònic de l'Empresa per poder utilitzar aquesta acció"
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_new
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_open
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_pending
-msgid "${object.name}"
-msgstr "${object.name}"
+#: code:addons/crm_poweremail/crm.py:197
+#, python-format
+msgid "Poweremail template \"Email CC\" has bad formatted address"
+msgstr "La direcció \"CC\" de la plantilla Power E-mail no té un format correcte"
 
 #. module: crm_poweremail
 #: model:ir.module.module,description:crm_poweremail.module_meta_information

--- a/i18n/crm_poweremail.pot
+++ b/i18n/crm_poweremail.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 5.0.14\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2017-10-06 13:40\n"
-"PO-Revision-Date: 2017-10-06 13:40\n"
+"POT-Creation-Date: 2017-11-02 17:07\n"
+"PO-Revision-Date: 2017-11-02 17:07\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,20 +16,14 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:229
-#, python-format
-msgid "Poweremail template \"Email BCC\" has bad formatted address"
+#: field:res.partner,domain:0
+msgid "Email domain"
 msgstr ""
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_pending
-msgid "Dear ${object.partner_id.name},\n"
-"\n"
-"The case with identifier: #${object.id} with the subject: \"${object.name}\" has been updated to the state 'Pending'.\n"
-"\n"
-"Awaiting for review.\n"
-"\n"
-"            "
+#: code:addons/crm_poweremail/crm.py:207
+#, python-format
+msgid "Poweremail template \"Email BCC\" has bad formatted address"
 msgstr ""
 
 #. module: crm_poweremail
@@ -38,38 +32,18 @@ msgid "Poweremail Template"
 msgstr ""
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_new
-msgid "Dear ${object.partner_id.name},\n"
-"\n"
-"In date ${date_now} we have recieved the case with the subject: ${object.name}\n"
-"Case Identifier: #${object.id}\n"
-"\n"
-"Waiting for a responsible to take over the case.\n"
-"\n"
-"            "
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_new
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_open
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_pending
+msgid "${object.name}"
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:221
-#, python-format
-msgid "Poweremail template \"Email CC\" has bad formatted address"
-msgstr ""
-
-#. module: crm_poweremail
-#: code:addons/crm_poweremail/poweremail_mailbox.py:72
+#: code:addons/crm_poweremail/poweremail_mailbox.py:158
+#: code:addons/crm_poweremail/poweremail_mailbox.py:167
 #, python-format
 msgid "Reply"
-msgstr ""
-
-#. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
-msgid "Dear ${object.partner_id.name},\n"
-"\n"
-"In date ${date_now} the case has been Opened with the subject: ${object.name}\n"
-"Case Identifier: #${object.id}\n"
-"Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}\n"
-"\n"
-"            "
 msgstr ""
 
 #. module: crm_poweremail
@@ -83,15 +57,47 @@ msgid "unknown"
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:109
-#, python-format
-msgid "Can not send mail with empty body,you should have description in the body"
+#: view:crm.case.rule:0
+msgid "E-Mail Actions"
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:127
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close
+msgid "Hi there,\n"
+"\n"
+"The case with identifier: #${object.id} with the subject: \"${object.name}\" has been CLOSED.\n"
+"\n"
+"            "
+msgstr ""
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
+msgid "Hi there,\n"
+"\n"
+"In date ${date_now} the case has been Opened with the subject: ${object.name}\n"
+"Case Identifier: #${object.id}\n"
+"\n"
+"Responsible: ${object.user_id.name} <${object.user_id.address_id.email}>\n"
+"\n"
+"            "
+msgstr ""
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:131
 #, python-format
 msgid "No E-Mail ID Found for your Company address!"
+msgstr ""
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_new
+msgid "Hi there,\n"
+"\n"
+"In date ${date_now} we have recieved the case with the subject: ${object.name}\n"
+"Case Identifier: #${object.id}\n"
+"\n"
+"Waiting for a responsible to take over the case.\n"
+"\n"
+"            "
 msgstr ""
 
 #. module: crm_poweremail
@@ -100,35 +106,33 @@ msgid "Invalid XML for View Architecture!"
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:213
+#: code:addons/crm_poweremail/poweremail_mailbox.py:41
+#, python-format
+msgid "Could not parse poweremail_mailbox pem_from address with qreu"
+msgstr ""
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:189
 #, python-format
 msgid "Poweremail template \"Email TO\" has bad formatted address"
 msgstr ""
 
 #. module: crm_poweremail
-#: view:crm.case.rule:0
-msgid "E-Mail Actions"
-msgstr ""
-
-#. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close
-msgid "Dear ${object.partner_id.name},\n"
-"\n"
-"The case with identifier: #${object.id} with the subject: \"${object.name}\" has been CLOSED.\n"
-"\n"
-"            "
+#: code:addons/crm_poweremail/crm.py:113
+#, python-format
+msgid "Can not send mail with empty body,you should have description in the body"
 msgstr ""
 
 #. module: crm_poweremail
 #: code:addons/crm_poweremail/crm.py:60
 #: code:addons/crm_poweremail/crm.py:67
-#: code:addons/crm_poweremail/crm.py:101
-#: code:addons/crm_poweremail/crm.py:104
+#: code:addons/crm_poweremail/crm.py:105
 #: code:addons/crm_poweremail/crm.py:108
-#: code:addons/crm_poweremail/crm.py:126
-#: code:addons/crm_poweremail/crm.py:213
-#: code:addons/crm_poweremail/crm.py:221
-#: code:addons/crm_poweremail/crm.py:229
+#: code:addons/crm_poweremail/crm.py:112
+#: code:addons/crm_poweremail/crm.py:130
+#: code:addons/crm_poweremail/crm.py:189
+#: code:addons/crm_poweremail/crm.py:197
+#: code:addons/crm_poweremail/crm.py:207
 #, python-format
 msgid "Error!"
 msgstr ""
@@ -146,13 +150,13 @@ msgid "No E-Mail ID Found for your Company address or missing reply address in s
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:129
+#: code:addons/crm_poweremail/crm.py:133
 #, python-format
 msgid "Send"
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:105
+#: code:addons/crm_poweremail/crm.py:109
 #, python-format
 msgid "You must define a responsible user for this case in order to use this action!"
 msgstr ""
@@ -183,17 +187,26 @@ msgid "PowerEmail Template"
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:102
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_pending
+msgid "Hi there,\n"
+"\n"
+"The case with identifier: #${object.id} with the subject: \"${object.name}\" has been updated to the state 'Pending'.\n"
+"\n"
+"Awaiting for review.\n"
+"\n"
+"            "
+msgstr ""
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:106
 #, python-format
 msgid "You must put a Partner eMail to use this action!"
 msgstr ""
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_new
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_open
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_pending
-msgid "${object.name}"
+#: code:addons/crm_poweremail/crm.py:197
+#, python-format
+msgid "Poweremail template \"Email CC\" has bad formatted address"
 msgstr ""
 
 #. module: crm_poweremail

--- a/i18n/es_ES.po
+++ b/i18n/es_ES.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GISCE-ERP\n"
 "Report-Msgid-Bugs-To: https://github.com/gisce/erp/issues\n"
-"POT-Creation-Date: 2017-10-06 13:40\n"
-"PO-Revision-Date: 2017-10-06 11:41+0000\n"
+"POT-Creation-Date: 2017-11-02 17:07\n"
+"PO-Revision-Date: 2017-11-02 16:30+0000\n"
 "Last-Translator: Jaume  Florez Valenzuela <jflorez@gisce.net>\n"
 "Language-Team: Spanish (Spain) <erp@dev.gisce.net>\n"
 "MIME-Version: 1.0\n"
@@ -18,22 +18,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:229
+#: field:res.partner,domain:0
+msgid "Email domain"
+msgstr "Dominio de Correo"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:207
 #, python-format
 msgid "Poweremail template \"Email BCC\" has bad formatted address"
 msgstr "La dirección \"BCC\" de la plantilla Power E-mail no tiene un formato correcto"
-
-#. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_pending
-msgid ""
-"Dear ${object.partner_id.name},\n"
-"\n"
-"The case with identifier: #${object.id} with the subject: \"${object.name}\" has been updated to the state 'Pending'.\n"
-"\n"
-"Awaiting for review.\n"
-"\n"
-"            "
-msgstr "Estimado/da ${object.partner_id.name},\n\nEl caso con identificador: #${object.id} con el asunto: \"${object.name}\"; ha pasado al estado: 'Pending'.\n\nEsperando revisión."
 
 #. module: crm_poweremail
 #: field:crm.case.rule,pm_template_id:0
@@ -41,41 +34,19 @@ msgid "Poweremail Template"
 msgstr "Plantilla Poweremail"
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_new
-msgid ""
-"Dear ${object.partner_id.name},\n"
-"\n"
-"In date ${date_now} we have recieved the case with the subject: ${object.name}\n"
-"Case Identifier: #${object.id}\n"
-"\n"
-"Waiting for a responsible to take over the case.\n"
-"\n"
-"            "
-msgstr "Estimado/da ${object.partner_id.name},\n\nEn fecha ${date_now} hemos recibido un caso con el asunto: ${object.name}\n\nIdentificador del Caso: #${object.id}\n\nEsperando la asignación de un responsable.\n\n             \n\n      "
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_new
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_open
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_pending
+msgid "${object.name}"
+msgstr "${object.name}"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:221
-#, python-format
-msgid "Poweremail template \"Email CC\" has bad formatted address"
-msgstr "La dirección \"CC\" de la plantilla Power E-mail no tiene un formato correcto"
-
-#. module: crm_poweremail
-#: code:addons/crm_poweremail/poweremail_mailbox.py:72
+#: code:addons/crm_poweremail/poweremail_mailbox.py:158
+#: code:addons/crm_poweremail/poweremail_mailbox.py:167
 #, python-format
 msgid "Reply"
 msgstr "Resposta"
-
-#. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
-msgid ""
-"Dear ${object.partner_id.name},\n"
-"\n"
-"In date ${date_now} the case has been Opened with the subject: ${object.name}\n"
-"Case Identifier: #${object.id}\n"
-"Responsible: ${object.user_id.name} - ${object.user_id.address_id.email}\n"
-"\n"
-"            "
-msgstr "Estimado/da ${object.partner_id.name},\n\nEn fecha ${date_now} el caso se ha Abierto con el asunto: ${object.name}\n\nIdentificador del Caso: #${object.id}\nResponsable: ${object.user_id.name} - {object.user_id.address_id.email}\n\n       "
 
 #. module: crm_poweremail
 #: view:crm.case:0
@@ -88,30 +59,6 @@ msgid "unknown"
 msgstr "desconocido"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:109
-#, python-format
-msgid ""
-"Can not send mail with empty body,you should have description in the body"
-msgstr "No se puede enviar un correo sin cuerpo, debería haber una descripción en el cuerpo"
-
-#. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:127
-#, python-format
-msgid "No E-Mail ID Found for your Company address!"
-msgstr "No se ha encontrado un ID de correo electrónico para la dirección de su Compañía!"
-
-#. module: crm_poweremail
-#: constraint:ir.ui.view:0
-msgid "Invalid XML for View Architecture!"
-msgstr "Arquitectura de XML inválida"
-
-#. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:213
-#, python-format
-msgid "Poweremail template \"Email TO\" has bad formatted address"
-msgstr "La dirección \"TO\" de la plantilla Power E-mail no tiene un formato correcto"
-
-#. module: crm_poweremail
 #: view:crm.case.rule:0
 msgid "E-Mail Actions"
 msgstr "Acciones de Correo Electrónico"
@@ -119,19 +66,75 @@ msgstr "Acciones de Correo Electrónico"
 #. module: crm_poweremail
 #: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close
 msgid ""
-"Dear ${object.partner_id.name},\n"
+"Hi there,\n"
 "\n"
 "The case with identifier: #${object.id} with the subject: \"${object.name}\" has been CLOSED.\n"
 "\n"
 "            "
-msgstr "Estimado/da ${object.partner_id.name},\n\nEl caso con el identificador: #${object.id}; con el asunto: \"${object.name}\" se ha CERRADO.\n\n    "
+msgstr "Buenos días,\n\nEl caso con el identificador: #${object.id}; con el asunto: \"${object.name}\" se ha CERRADO.\n\n             "
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
+msgid ""
+"Hi there,\n"
+"\n"
+"In date ${date_now} the case has been Opened with the subject: ${object.name}\n"
+"Case Identifier: #${object.id}\n"
+"\n"
+"Responsible: ${object.user_id.name} <${object.user_id.address_id.email}>\n"
+"\n"
+"            "
+msgstr "Buenos días,\n\nEn fecha ${date_now} el caso se ha Abierto con el asunto: ${object.name}\n\nIdentificador del Caso: #${object.id}\\nResponsable: ${object.user_id.name} - {object.user_id.address_id.email}\n\n       "
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:131
+#, python-format
+msgid "No E-Mail ID Found for your Company address!"
+msgstr "No se ha encontrado un ID de correo electrónico para la dirección de su Compañía!"
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_new
+msgid ""
+"Hi there,\n"
+"\n"
+"In date ${date_now} we have recieved the case with the subject: ${object.name}\n"
+"Case Identifier: #${object.id}\n"
+"\n"
+"Waiting for a responsible to take over the case.\n"
+"\n"
+"            "
+msgstr "Buenos días,\n\nEn fecha ${date_now} hemos recibido un caso con el asunto: ${object.name}\n\nIdentificador del Caso: #${object.id}\n\nEsperando la asignación de un responsable.\n\n             "
+
+#. module: crm_poweremail
+#: constraint:ir.ui.view:0
+msgid "Invalid XML for View Architecture!"
+msgstr "Arquitectura de XML inválida"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/poweremail_mailbox.py:41
+#, python-format
+msgid "Could not parse poweremail_mailbox pem_from address with qreu"
+msgstr "No se puede tratar la dirección \"pem from\" del mensaje de poweremail con \"qreu\""
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:189
+#, python-format
+msgid "Poweremail template \"Email TO\" has bad formatted address"
+msgstr "La dirección \"TO\" de la plantilla Power E-mail no tiene un formato correcto"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:113
+#, python-format
+msgid ""
+"Can not send mail with empty body,you should have description in the body"
+msgstr "No se puede enviar un correo sin cuerpo, debería haber una descripción en el cuerpo"
 
 #. module: crm_poweremail
 #: code:addons/crm_poweremail/crm.py:60 code:addons/crm_poweremail/crm.py:67
-#: code:addons/crm_poweremail/crm.py:101 code:addons/crm_poweremail/crm.py:104
-#: code:addons/crm_poweremail/crm.py:108 code:addons/crm_poweremail/crm.py:126
-#: code:addons/crm_poweremail/crm.py:213 code:addons/crm_poweremail/crm.py:221
-#: code:addons/crm_poweremail/crm.py:229
+#: code:addons/crm_poweremail/crm.py:105 code:addons/crm_poweremail/crm.py:108
+#: code:addons/crm_poweremail/crm.py:112 code:addons/crm_poweremail/crm.py:130
+#: code:addons/crm_poweremail/crm.py:189 code:addons/crm_poweremail/crm.py:197
+#: code:addons/crm_poweremail/crm.py:207
 #, python-format
 msgid "Error!"
 msgstr "Error!"
@@ -153,13 +156,13 @@ msgid ""
 msgstr "No se ha encontrado el ID de correo electrónico para la dirección de su Compañía o en la dirección de resupesta de esta sección!"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:129
+#: code:addons/crm_poweremail/crm.py:133
 #, python-format
 msgid "Send"
 msgstr "Enviar"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:105
+#: code:addons/crm_poweremail/crm.py:109
 #, python-format
 msgid ""
 "You must define a responsible user for this case in order to use this "
@@ -192,18 +195,28 @@ msgid "PowerEmail Template"
 msgstr "Plantilla PowerEmail"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:102
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_pending
+msgid ""
+"Hi there,\n"
+"\n"
+"The case with identifier: #${object.id} with the subject: \"${object.name}\" has been updated to the state 'Pending'.\n"
+"\n"
+"Awaiting for review.\n"
+"\n"
+"            "
+msgstr "Buenos días,\n\nEl caso con identificador: #${object.id} con el asunto: \"${object.name}\"; ha pasado al estado: 'Pendiente'.\n\nEsperando revisión."
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:106
 #, python-format
 msgid "You must put a Partner eMail to use this action!"
 msgstr "Se debe facilitar la dirección de correo electrónico de la Empresa para utilitzar esta acción!"
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_new
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_open
-#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_pending
-msgid "${object.name}"
-msgstr "${object.name}"
+#: code:addons/crm_poweremail/crm.py:197
+#, python-format
+msgid "Poweremail template \"Email CC\" has bad formatted address"
+msgstr "La dirección \"CC\" de la plantilla Power E-mail no tiene un formato correcto"
 
 #. module: crm_poweremail
 #: model:ir.module.module,description:crm_poweremail.module_meta_information

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -64,10 +64,20 @@ class PoweremailMailboxCRM(osv.osv):
                     })
                 case_obj.create(cursor, uid, case_vals)
             else:
+                case_id = case_id[0]
+                old_descr = case_obj.read(
+                    cursor, uid, case_id, ['description']
+                )['description']
+                if old_descr:
+                    cases = case_obj.browse(cursor, uid, [case_id])
+                    case_obj._history(
+                        cursor, uid, cases, _('Reply'), history=True,
+                        email=mail.from_.address
+                    )
                 case_obj.write(cursor, uid, case_id, {
                     'description': body_text
                 })
-                cases = case_obj.browse(cursor, uid, case_id)
+                cases = case_obj.browse(cursor, uid, [case_id])
                 case_obj._history(
                     cursor, uid, cases, _('Reply'), history=True,
                     email=mail.from_.address

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -12,25 +12,30 @@ class PoweremailMailboxCRM(osv.osv):
     _name = 'poweremail.mailbox'
     _inherit = 'poweremail.mailbox'
 
-    def get_address_from_powermail_mailbox(self, cursor, uid, p_mail):
+    def get_partner_address(self, cursor, uid, p_mail_id):
         """
         Gets or Creates the 'res.partner.address' from a poweremail_mailbox
-        :param cursor:  OpenERP Cursor
-        :param uid:     OpenERP User ID
-        :param p_mail:  PowerEmail Mailbox object (browsed)
-        :return:        Res.Partner.Address (browsed)
+        :param cursor:      OpenERP Cursor
+        :param uid:         OpenERP User ID
+        :param p_mail_id:   PowerEmail Mailbox object ID
+        :return:            Res.Partner.Address (browsed)
         """
         address_obj = self.pool.get('res.partner.address')
         partner_obj = self.pool.get('res.partner')
-        mail = qreu.Email(p_mail.pem_mail_orig)
+        p_mail = self.pool.get('poweremail.mailbox').read(
+            cursor, uid, p_mail_id, ['pem_mail_orig', 'pem_from']
+        )
+        mail = qreu.Email(p_mail['pem_mail_orig'])
         try:
             address_id = address_obj.search(cursor, uid, [
-                ('email', '=', qreu.address.parse(p_mail.pem_from).address)
+                ('email', '=', qreu.address.parse(p_mail['pem_from']).address)
             ])
         except Exception as err:
             import logging
             logging.getLogger('poweremail.mailbox').error(
-                'Could not parse poweremail_mailbox from address with qreu')
+                _('Could not parse poweremail_mailbox '
+                  'pem_from address with qreu')
+            )
             return False
         if not address_id:
             # If not found: create partner address

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -65,6 +65,7 @@ class PoweremailMailboxCRM(osv.osv):
                     address_id = addr_id[0]
                     partner_id = address['partner_id'][0]
                 else:
+                    partner_obj = self.pool.get('res.partner')
                     address_email = mail.from_.address
                     address_name = mail.from_.display_name or address_email
                     new_address = add_obj.create(cursor, uid, {
@@ -72,7 +73,18 @@ class PoweremailMailboxCRM(osv.osv):
                         'email': address_email
                     })
                     address_id = new_address.id
-                    partner_id = new_address.partner_id or False
+                    domain = address_email.split('@')[-1]
+                    partner_id = partner_obj.search(
+                        cursor, uid, [
+                            ('domain', '=', domain)
+                        ]
+                    )
+                    if partner_id:
+                        add_obj.write(
+                            cursor, uid, address_id, {'partner_id': partner_id}
+                        )
+                    else:
+                        partner_id = False
 
                 case_vals.update({
                     'partner_address_id': address_id,

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -141,18 +141,10 @@ class PoweremailMailboxCRM(osv.osv):
             case_id = case_obj.search(cursor, uid, [
                 ('conversation_id', '=', p_mail.conversation_id.id)
             ])
-            # If forwarding case e-mail, just send the e-mail
-            if mail.from_.address == section.reply_to:
-                cases = case_obj.browse(cursor, uid, case_id)
-                case_obj._history(
-                    cursor, uid, cases, _('Forward'), history=False,
-                    email=mail.from_.address
-                )
-                return res_id
             if not case_id:
                 # If not found a conversation, add new case with email values
-                case = self.create_case_from_mail(
-                    cursor, uid, p_mail, body_text, section
+                case = self.create_crm_case(
+                    cursor, uid, p_mail.id, section_id, body_text=body_text
                 )
 
             else:

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -139,6 +139,8 @@ class PoweremailMailboxCRM(osv.osv):
             body_text = quotations.extract_from_plain(p_mail.pem_body_text)
             section_id = section_id[0]
             section = section_obj.browse(cursor, uid, section_id)
+            if mail.from_ == section.reply_to:
+                return res_id
             case_id = case_obj.search(cursor, uid, [
                 ('conversation_id', '=', p_mail.conversation_id.id)
             ])

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -173,12 +173,12 @@ class PoweremailMailboxCRM(osv.osv):
                 # if not in e-mail recipients
                 email_from = section.reply_to
                 email_to = []
-                if case.email_from not in mail.to.addresses:
+                if case.email_from not in reply_to:
                     email_to.append(case.email_from)
-                if case.partner_address_id.email not in mail.to.addresses:
+                if case.partner_address_id.email not in reply_to:
                     email_to.append(case.partner_address_id.email)
                 for cc_email in case.email_cc:
-                    if not cc_email in mail.to.addresses:
+                    if not cc_email in reply_to:
                         email_to.append(cc_email)
                 if email_to:
                     email_to = list(set(email_to))

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -126,9 +126,18 @@ class PoweremailMailboxCRM(osv.osv):
             p_mail = self.browse(cursor, uid, res_id, context=context)
             body_text = quotations.extract_from_plain(p_mail.pem_body_text)
             section_id = section_id[0]
+            section = section_obj.browse(cursor, uid, section_id)
             case_id = case_obj.search(cursor, uid, [
                 ('conversation_id', '=', p_mail.conversation_id.id)
             ])
+            # If forwarding case e-mail, just send the e-mail
+            if mail.from_.address == section.reply_to:
+                cases = case_obj.browse(cursor, uid, case_id)
+                case_obj._history(
+                    cursor, uid, cases, _('Forward'), history=False,
+                    email=mail.from_.address
+                )
+                return res_id
             if not case_id:
                 # If not found a conversation, add new case with email values
                 add_obj = self.pool.get('res.partner.address')

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -63,7 +63,7 @@ class PoweremailMailboxCRM(osv.osv):
                 address_obj.write(
                     cursor, uid, address_id, {'partner_id': partner_id}
                 )
-        return address_obj.browse(cursor, uid, address_id)
+        return address_obj.browse(cursor, uid, address_id) or False
 
     def create_crm_case(self, cursor, uid, p_mail_id, section_id,
                         body_text=False, context=None):

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -42,7 +42,9 @@ class PoweremailMailboxCRM(osv.osv):
                   'pem_from address with qreu')
             )
             return False
-        if not address_id:
+        if address_id:
+            address_id = address_id[0]
+        else:
             # If not found: create partner address
             address_email = mail.from_.address
             address_name = mail.from_.display_name or address_email

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -2,6 +2,8 @@
 from osv import osv
 from tools.translate import _
 from talon import quotations
+from datetime import datetime
+from email.utils import make_msgid
 
 import qreu
 
@@ -180,16 +182,22 @@ class PoweremailMailboxCRM(osv.osv):
                 if email_to:
                     email_to = list(set(email_to))
                     mailbox_obj = self.pool.get('poweremail.mailbox')
-                    vals2 = vals.copy()
-                    vals2.update({
+                    vals_forward = {}
+                    vals_forward.update({
                         'pem_to': email_to[0],
                         'pem_from': email_from,
                         'pem_cc': email_to[1:] if len(email_to[1:]) else False,
-                        'pem_bcc': False,
+                        'pem_subject': p_mail.pem_subject,
+                        'pem_body_text': p_mail.pem_body_text,
+                        'pem_body_html': p_mail.pem_body_html,
                         'pem_folder': 'outbox',
-                        'mail_type': 'multipart/alternative'
+                        'pem_account_id': p_mail.pem_account_id.id,
+                        'mail_type': 'multipart/alternative',
+                        'date_mail': datetime.now().strftime('%Y-%m-%d'),
+                        'pem_message_id': make_msgid('tinycrm-%s' % case.id),
+                        'conversation_id': case.conversation_id.id,
                     })
-                    mailbox_obj.create(cursor, uid, vals2)
+                    mailbox_obj.create(cursor, uid, vals_forward)
         return res_id
  
 PoweremailMailboxCRM()

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -19,8 +19,11 @@ class PoweremailMailboxCRM(osv.osv):
         Gets or Creates the 'res.partner.address' from a poweremail_mailbox
         :param cursor:      OpenERP Cursor
         :param uid:         OpenERP User ID
+        :type uid:          int
         :param p_mail_id:   PowerEmail Mailbox object ID
+        :type p_mail_id:    int
         :return:            Res.Partner.Address (browsed)
+        :rtype:             osv.osv
         """
         address_obj = self.pool.get('res.partner.address')
         partner_obj = self.pool.get('res.partner')
@@ -66,11 +69,17 @@ class PoweremailMailboxCRM(osv.osv):
         Creates a CRM.case object from a poweremail.mailbox object
         :param cursor:      OpenERP Cursor
         :param uid:         OpenERP User ID
+        :type uid:          int
         :param p_mail_id:   PowerEmail Mailbox object
+        :type p_mail_id:    int
         :param section_id:  CRM.case.section that the new case must belong
+        :type section_id:   int
         :param body_text:   Mail body parsed, used in the CRM.case.description
+        :type body_text:    str
         :param context:     OpenERP Context, passed to the create method
-        :return:
+        :type context:      dict
+        :return:            New crm.case object (browsed)
+        :rtype:             osv.osv
         """
         if context is None:
             context = {}

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -180,7 +180,7 @@ class PoweremailMailboxCRM(osv.osv):
                 if case.partner_address_id.email not in reply_to:
                     email_to.append(case.partner_address_id.email)
                 for cc_email in case.email_cc:
-                    if not cc_email in reply_to:
+                    if cc_email not in reply_to:
                         email_to.append(cc_email)
                 if email_to:
                     email_to = list(set(email_to))

--- a/res_partner.py
+++ b/res_partner.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from osv import osv, fields
+
+
+class ResPartnerDomain(osv.osv):
+    # Add e-mail domain to res.partner for res.partner.address auto-creation
+
+    _name = 'res.partner'
+    _inherit = 'res.partner'
+
+    _columns = {
+        'domain': fields.char('Email domain', size=128),
+    }
+
+ResPartnerDomain()

--- a/res_partner_view.xml
+++ b/res_partner_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_res_partner_domain">
+            <field name="name">res.partner.domain</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_partner_form"/>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <field name="parent_id" position="before">
+                    <field name="domain" select="2"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
- [x] Update templates without res.partner[name]
- [x] Fix crm_rules
- [x] add `no_update=1` to `crm_data.xml`
- [x] translate
- [ ] Update mailbox creation
  - [x] Add get_partner_address from pwemail
  - [x] Create partner_address from pwemail
  - [x] Forward messages to missing recipients of crm_case (from: section.reply_to)