### PR TITLE
Fix default argument on filter_mails method

### DIFF
--- a/crm.py
+++ b/crm.py
@@ -14,7 +14,7 @@ class CrmCase(osv.osv):
     _inherit = 'crm.case'
 
     @staticmethod
-    def filter_mails(emails, email_from, case, todel_emails=False):
+    def filter_mails(emails, email_from, case, todel_emails=[]):
         """
         :param emails:
         :type emails:           [str]


### PR DESCRIPTION
Fix #11 

Default "`todel_emails`" on "`filter_mails`" as `False` may raise Exception on list comprehension built (`bool is not iterable`).