### PR TITLE
Add missing security access rules

### DIFF
--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -1,3 +1,7 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 "access_pe_template_case_manager","poweremail.templates","poweremail.model_poweremail_templates","crm.group_crm_manager",1,1,1,1
 "access_pe_template_case_users","poweremail.templates","poweremail.model_poweremail_templates","crm.group_crm_user",1,1,0,0
+"access_pe_template_case_manager","poweremail.core_accounts","poweremail.model_poweremail_core_accounts","crm.group_crm_manager",1,1,1,1
+"access_pe_template_case_users","poweremail.core_accounts","poweremail.model_poweremail_core_accounts","crm.group_crm_user",1,0,0,0
+"access_pe_template_case_manager","poweremail.mailbox","poweremail.model_poweremail_mailbox","crm.group_crm_manager",1,1,1,1
+"access_pe_template_case_users","poweremail.mailbox","poweremail.model_poweremail_mailbox","crm.group_crm_user",1,1,1,0


### PR DESCRIPTION
Adds missing security rules for CRM User and Manager on PowerEmail elements:

- Poweremail Core Accounts
- Poweremail Mailbox