### PR TITLE
Improve domain search on Partner address domain

### DIFF
--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -52,14 +52,18 @@ class PoweremailMailboxCRM(osv.osv):
                 'name': address_name,
                 'email': address_email
             })
-            domain = address_email.split('@')[-1]
+            domain = address_email.split('@')[-1].strip()
             partner_id = partner_obj.search(
-                cursor, uid, [
-                    '|',
-                    ('domain', 'ilike', '%' + domain),
-                    ('domain', 'ilike', domain + '%')
-                ]
+                cursor, uid, [('domain', '=', domain)]
             )
+            if not partner_id:
+                partner_id = partner_obj.search(
+                    cursor, uid, [
+                        '|',
+                        ('domain', 'ilike', '%' + domain),
+                        ('domain', 'ilike', domain + '%')
+                    ]
+                )
             if partner_id:
                 address_obj.write(
                     cursor, uid, address_id, {'partner_id': partner_id[0]}

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -56,14 +56,6 @@ class PoweremailMailboxCRM(osv.osv):
             partner_id = partner_obj.search(
                 cursor, uid, [('domain', '=', domain)]
             )
-            if not partner_id:
-                partner_id = partner_obj.search(
-                    cursor, uid, [
-                        '|',
-                        ('domain', 'ilike', '%' + domain),
-                        ('domain', 'ilike', domain + '%')
-                    ]
-                )
             if partner_id:
                 address_obj.write(
                     cursor, uid, address_id, {'partner_id': partner_id[0]}

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -55,7 +55,9 @@ class PoweremailMailboxCRM(osv.osv):
             domain = address_email.split('@')[-1]
             partner_id = partner_obj.search(
                 cursor, uid, [
-                    ('domain', '=', domain)
+                    '|',
+                    ('domain', 'ilike', '%' + domain),
+                    ('domain', 'ilike', domain + '%')
                 ]
             )
             if partner_id:


### PR DESCRIPTION
Improve domain search with ilike and wildcarts

- [x] Search for partners which domain is like the email's domain (Only if not found as equal).
- [x] Remove trailing characters (spaces and that sort of chars) from email domain.