### PR TITLE
Add watchers page on crm_case

### DIFF
--- a/__terp__.py
+++ b/__terp__.py
@@ -14,15 +14,17 @@
     "depends":[
         "base",
         "crm",
-        "poweremail"
+        "poweremail",
     ],
     "init_xml": [],
-    "demo_xml": [],
+    "demo_xml": [
+        "crm_demo.xml",
+    ],
     "update_xml":[
         "crm_view.xml",
         "crm_data.xml",
         "res_partner_view.xml",
-        "security/ir.model.access.csv"
+        "security/ir.model.access.csv",
     ],
     "active": False,
     "installable": True

--- a/crm.py
+++ b/crm.py
@@ -187,7 +187,17 @@ class CrmCase(osv.osv):
             type='one2many',
             obj='poweremail.mailbox',
             method=True
-        )
+        ),
+        'email_bcc': fields.char('Secret Watchers Emails', size=252),
+        'cc_address_ids': fields.many2many(
+            obj='res.partner.address', rel='crm_case_watchers_address',
+            id1='case_id', id2='address_id', string='Watchers Addresses (CC)'
+        ),
+        'bcc_address_ids': fields.many2many(
+            obj='res.partner.address', rel='crm_case_secret_watchers_address',
+            id1='case_id', id2='address_id',
+            string='Secret Watchers Addresses (BCC)'
+        ),
     }
 
 CrmCase()

--- a/crm_demo.xml
+++ b/crm_demo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="crmpoweremail_pem_account01" model="poweremail.core_accounts">
+            <field name="name">Test Account</field>
+            <field name="email_id">test@example.com</field>
+            <field name="company">no</field>
+            <field name="smtpserver">smtp.example.com</field>
+            <field name="smtpport">1234</field>
+            <field name="smtpuname">test</field>
+            <field name="smtppass">True</field>
+            <field name="state">approved</field>
+        </record>
+        <record id="crmpoweremail_section01" model="crm.case.section">
+            <field name="name">crm_poweremail</field>
+            <field name="reply_to">test@example.com</field>
+        </record>
+        <!-- DEMO CASE WITH EMAIL ADDRESS -->
+        <record id="crmpoweremail_case01" model="crm.case">
+            <field name="name">CASE 0001</field>
+            <field name="section_id" ref="crmpoweremail_section01"/>
+            <field name="email_cc">test2@mail.com, me@example.com</field>
+            <field name="email_bcc">test@mail.com, test@example.com</field>
+        </record>
+    </data>
+</openerp>

--- a/crm_view.xml
+++ b/crm_view.xml
@@ -11,6 +11,24 @@
             		<page string="Conversations">
             			<field name="conversation_mails" nolabel="1" colspan="4" />
             		</page>
+                    <page string="Watchers">
+                        <field name="email_cc" readonly="1" colspan="4"/>
+                        <field name="cc_address_ids" mode="tree,form" colspan="4">
+                            <tree>
+                                <field name="partner_id"/>
+                                <field name="name"/>
+                                <field name="email"/>
+                            </tree>
+                        </field>
+                        <field name="email_bcc" readonly="1" colspan="4"/>
+                        <field name="bcc_address_ids" mode="tree,form" colspan="4">
+                            <tree>
+                                <field name="partner_id"/>
+                                <field name="name"/>
+                                <field name="email"/>
+                            </tree>
+                        </field>
+                    </page>
             	</page>
             </field>
         </record>

--- a/crm_view.xml
+++ b/crm_view.xml
@@ -12,16 +12,18 @@
             			<field name="conversation_mails" nolabel="1" colspan="4" />
             		</page>
                     <page string="Watchers">
-                        <field name="email_cc" readonly="1" colspan="4"/>
-                        <field name="cc_address_ids" mode="tree,form" colspan="4">
+                        <field name="email_cc" colspan="4"/>
+                        <field name="cc_address_ids" mode="tree,form" colspan="4"
+                               on_change="_onchange_address_ids('cc', cc_address_ids)">
                             <tree>
                                 <field name="partner_id"/>
                                 <field name="name"/>
                                 <field name="email"/>
                             </tree>
                         </field>
-                        <field name="email_bcc" readonly="1" colspan="4"/>
-                        <field name="bcc_address_ids" mode="tree,form" colspan="4">
+                        <field name="email_bcc" colspan="4"/>
+                        <field name="bcc_address_ids" mode="tree,form" colspan="4"
+                               on_change="_onchange_address_ids('bcc', bcc_address_ids)">
                             <tree>
                                 <field name="partner_id"/>
                                 <field name="name"/>

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -180,13 +180,19 @@ class PoweremailMailboxCRM(osv.osv):
                 # if not in e-mail recipients
                 email_from = section.reply_to
                 email_to = []
+                email_bcc = []
                 if case.email_from not in reply_to:
                     email_to.append(case.email_from)
                 if case.partner_address_id.email not in reply_to:
                     email_to.append(case.partner_address_id.email)
-                for cc_email in case.email_cc:
-                    if cc_email not in reply_to:
-                        email_to.append(cc_email)
+                for cc_email in case.email_cc.split(','):
+                    cc = cc_email.strip()
+                    if cc not in reply_to:
+                        email_to.append(cc)
+                for bcc_email in case.email_bcc.split(','):
+                    bcc = bcc_email.strip()
+                    if bcc not in email_to:
+                        email_bcc.append(bcc)
                 if email_to:
                     email_to = list(set(email_to))
                     mailbox_obj = self.pool.get('poweremail.mailbox')
@@ -195,6 +201,7 @@ class PoweremailMailboxCRM(osv.osv):
                         'pem_to': email_to[0],
                         'pem_from': email_from,
                         'pem_cc': email_to[1:] if len(email_to[1:]) else False,
+                        'pem_bcc': email_bcc,
                         'pem_subject': p_mail.pem_subject,
                         'pem_body_text': p_mail.pem_body_text,
                         'pem_body_html': p_mail.pem_body_html,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,52 @@
+# coding=utf-8
+from __future__ import unicode_literals
+from dateutil.relativedelta import relativedelta
+from datetime import datetime
+
+from destral import testing
+from destral.transaction import Transaction
+from expects import *
+
+import logging
+
+
+class TestCRMPoweremail(testing.OOTestCase):
+    def setUp(self):
+        self.txn = Transaction().start(self.database)
+        self.logger = logging.getLogger(__name__)
+        self.cursor = self.txn.cursor
+        self.uid = self.txn.user
+        self.pool = self.txn.pool
+
+    def tearDown(self):
+        self.txn.stop()
+
+    def test_onchange_address_ids(self):
+        # def _onchange_address_ids(
+        # cursor, uid, ids,addr_type=False, addr_ids=False,context=None
+        imod_obj = self.pool.get('ir.model.data')
+        case_obj = self.pool.get('crm.case')
+        case_id = imod_obj.get_object_reference(
+            self.cursor, self.uid, 'crm_poweremail', 'crmpoweremail_case01')[1]
+        case = case_obj.browse(self.cursor, self.uid, case_id)
+        self.assertEqual(case.email_cc, 'test2@mail.com, me@example.com')
+        self.assertEqual(case.email_bcc, 'test@mail.com, test@example.com')
+        appended_string = 'testing@example.com, test2@mail.com, me@example.com'
+        not_appended_string = 'test2@mail.com, me@example.com'
+        self.assertEqual(
+            case._onchange_address_ids('cc', [[1, 1, [1]]]), {
+                'value': {
+                    'email_cc': appended_string
+                }
+            },
+            msg='Appended string does not match with the new address'
+        )
+        case.write({'email_cc': appended_string})
+        self.assertEqual(
+            case._onchange_address_ids('cc', [[1, 1, []]]), {
+                'value': {
+                    'email_cc': not_appended_string
+                }
+            },
+            msg='Removing address does not return correct string'
+        )


### PR DESCRIPTION
Closes #25 

- [x] ADD Watchers Page
  - [x] ADD email_bcc ~as read_only~
  - [x] ADD email_cc ~as read_only~
  - [x] ADD watchers_bcc
  - [x] ADD watchers_ccc
  - [x] ~DEL email_cc from original view~ → Keep it so you can add an email without a partner
- [x] ADD watchers to crm_case mail sending
- [x] ADD "automatic" update tests
- [x] ADD "automatic" update of email_cc and email_bcc with watchers → on_change on many2many
