### PR TITLE
IMP email sending methods

### DIFF
--- a/crm.py
+++ b/crm.py
@@ -127,7 +127,8 @@ class CrmCase(osv.osv):
         if isinstance(case_id, (list, tuple)):
             case_id = case_id[0]
         watchers_bcc = self.read(
-            cursor, uid, [case_id], ['email_bcc'], context=context)['email_bcc']
+            cursor, uid, [case_id], ['email_bcc'], context=context
+        )[0]['email_bcc'] or []
         emails = super(CrmCase, self).get_cc_emails(
             cursor, uid, case_id, context=context)
         return list(set(emails+watchers_bcc+context.get('email_bcc', [])))

--- a/crm.py
+++ b/crm.py
@@ -129,7 +129,7 @@ class CrmCase(osv.osv):
         watchers_bcc = self.read(
             cursor, uid, [case_id], ['email_bcc'], context=context
         )[0]['email_bcc'] or []
-        emails = super(CrmCase, self).get_cc_emails(
+        emails = super(CrmCase, self).get_bcc_emails(
             cursor, uid, case_id, context=context)
         return list(set(emails+watchers_bcc+context.get('email_bcc', [])))
 


### PR DESCRIPTION
## Objetives

- Update code to work from BASE email sending
- ADD watchers email to mail sending

## Old Behaviour

- Este módulo añadía el mismo método que hay ahora en base
- CC y BCC de Watchers se añadían por el context i era confuso

## New Behaviour

- CC y BCC se añaden en los métodos de obtención de correos de BASE

## Migrations

- N/A

## Configuration Variables

- N/A

## Related

- Closes #28 
- Requires https://github.com/gisce/erp/pull/6828

## Checklist

- [x] Remove duplicated code from base CRM
- [x] Use base CRM get addresses (CC and BCC)
- [x] Override CRM get addresses to get case watchers