### PR TITLE
ADD Case-related attachments

### DIFF
--- a/crm_view.xml
+++ b/crm_view.xml
@@ -40,6 +40,15 @@
                             </tree>
                         </field>
                     </page>
+                    <page string="Case-Related Attachments">
+                        <field name="attachment_ids" nolabel="1">
+                            <tree>
+                                <field name="datas_fname"/>
+                                <field name="create_date"/>
+                                <field name="associated_object"/>
+                            </tree>
+                        </field>
+                    </page>
             	</page>
             </field>
         </record>

--- a/crm_view.xml
+++ b/crm_view.xml
@@ -52,6 +52,7 @@
             	</page>
             </field>
         </record>
+
 		<record id="crm_case_rule-pmail-view" model="ir.ui.view">
             <field name="name">crm.case.rule.form</field>
             <field name="model">crm.case.rule</field>
@@ -80,6 +81,23 @@
                     <field name="pm_template_id"/>
                 </field>
             </field>
+        </record>
+
+        <record model="ir.actions.act_window" id="action_sc_link_case_emails">
+            <field name="name">Conversation Emails</field>
+            <field name="res_model">poweremail.mailbox</field>
+            <field name="src_model">crm.case</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="domain">[('id', 'in', conversation_mails)]</field>
+        </record>
+        <record id="value_action_sc_link_case_emails" model="ir.values">
+            <field name="object" eval="1"/>
+            <field name="name">Conversation Emails</field>
+            <field name="key2">client_action_relate</field>
+            <field name="key">action</field>
+            <field name="model">crm.case</field>
+            <field name="value" eval="'ir.actions.act_window,'+str(ref('action_sc_link_case_emails'))" />
         </record>
 	</data>
 </openerp>

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -293,7 +293,6 @@ class PoweremailMailboxCRM(osv.osv):
         search_params = [('reply_to', 'in', reply_to)]
         section_id = section_obj.search(cursor, uid, search_params)
         if section_id:
-            body_text = quotations.extract_from_plain(p_mail.pem_body_text)
             section_id = section_id[0]
             section = section_obj.browse(cursor, uid, section_id)
             if mail.from_.address == section.reply_to:


### PR DESCRIPTION
The poweremail attachments can't be oppened directly from conversation emails.
And finding the emails is hard.

We add a new tab on CRM.Case to show all attachments related to the CRM.Case.
And a link to the emails so we can manage them if required.

Closes #24 

- [x] ADD `attachment_ids` on `crm_case` as a _field function_ 
  - Get all attachments linked on poweremail_mailbox
  ![image](https://user-images.githubusercontent.com/19925414/41547522-b3d208f8-7320-11e8-8a04-a2caa80a08f6.png)
- [x] ADD `link` to the conversation emails on the `crm_case`
    ![image](https://user-images.githubusercontent.com/19925414/41547584-df54a77e-7320-11e8-85be-36db4559faaa.png)
