### PR TITLE
Stop filtering FW/RE text from emails on CRM.CASE

### DIFF
--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -303,9 +303,11 @@ class PoweremailMailboxCRM(osv.osv):
             ])
             if not case_id:
                 # If not found a conversation, add new case with email values
-                # body_text = quotations.extract_from_plain(p_mail.pem_body_text)
+                # body_text = quotations.extract_from_plain(
+                #     p_mail.pem_body_text)
                 case = self.create_crm_case(
-                    cursor, uid, p_mail.id, section_id, body_text=body_text
+                    cursor, uid, p_mail.id, section_id,
+                    body_text=p_mail.pem_body_text
                 )
             else:
                 self.update_case_from_mail(

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -303,7 +303,7 @@ class PoweremailMailboxCRM(osv.osv):
             ])
             if not case_id:
                 # If not found a conversation, add new case with email values
-                body_text = quotations.extract_from_plain(p_mail.pem_body_text)
+                # body_text = quotations.extract_from_plain(p_mail.pem_body_text)
                 case = self.create_crm_case(
                     cursor, uid, p_mail.id, section_id, body_text=body_text
                 )


### PR DESCRIPTION
## PRE

Se filtra el texto de los correos para no mostrar el texto de respuestas y/o redirecciones de mensajes en la descripción del caso CRM.

## Post

En la descripción del caso CRM se muestra todo el texto del correo.
