### PR TITLE
Fix bugs: Init, forward and email getting

### DIFF
--- a/crm.py
+++ b/crm.py
@@ -403,16 +403,15 @@ class CrmCase(osv.osv):
         if context is None:
             context = {}
         attach_ids = {}
-        pwm_obj = self.pool.get('poweremail.mailbox')
+        attach_obj = self.pool.get('ir.attachment')
         for case in self.read(
             cursor, uid, ids, ['conversation_mails'], context=context
         ):
-            attach_ids[case['id']] = []
             # Get attachments from all emails
-            for email in case['conversation_mails']:
-                attach_ids[case['id']] += pwm_obj.read(cursor, uid, email, [
-                    'pem_attachments_ids'
-                ], context=context)['pem_attachments_ids']
+            attach_ids[case['id']] = attach_obj.search(cursor, uid, [
+                ('res_model', '=', 'poweremail.mailbox'),
+                ('res_id', 'in', case['conversation_mails'])
+            ])
         return attach_ids
     
     _columns = {

--- a/crm.py
+++ b/crm.py
@@ -6,6 +6,7 @@ from mako.template import Template
 from osv import osv, fields
 from tools.translate import _
 from tools import config
+from qreu import address as qaddress
 
 
 class CrmCase(osv.osv):
@@ -13,6 +14,22 @@ class CrmCase(osv.osv):
     """
     _name = 'crm.case'
     _inherit = 'crm.case'
+
+    @staticmethod
+    def filter_mails(emails, email_from, case, todel_emails=[]):
+        emails = super(CrmCase).filter_mails(
+            emails, email_from, case, todel_emails
+        )
+        filtered = []
+        for email in emails:
+            address = qaddress.parse(email)
+            try:
+                ind = [a.address for a in filtered].index(address.address)
+                if not filtered[ind].display_name and address.display_name:
+                    filtered[ind] = address
+            except ValueError:
+                filtered.append(address)
+        return filtered
 
     def _onchange_address_ids(
             self, cursor, uid, ids,

--- a/crm.py
+++ b/crm.py
@@ -270,9 +270,9 @@ class CrmCase(osv.osv):
             context = {}
         if isinstance(case_id, (list, tuple)):
             case_id = case_id[0]
-        watchers_bcc = self.read(
+        watchers_bcc = (self.read(
             cursor, uid, [case_id], ['email_bcc'], context=context
-        )[0]['email_bcc'] or []
+        )[0]['email_bcc'] or '').split(', ')
         emails = super(CrmCase, self).get_bcc_emails(
             cursor, uid, case_id, context=context)
         return list(set(emails+watchers_bcc+context.get('email_bcc', [])))
@@ -409,9 +409,9 @@ class CrmCase(osv.osv):
             attach_ids[case['id']] = []
             # Get attachments from all emails
             for email in case['conversation_mails']:
-                attach_ids[case['id']] += pwm_obj.read(cursor, uid, email[0], [
-                    'attachment_ids'
-                ], context=context)['attachment_ids']
+                attach_ids[case['id']] += pwm_obj.read(cursor, uid, email, [
+                    'pem_attachments_ids'
+                ], context=context)['pem_attachments_ids']
         return attach_ids
     
     _columns = {

--- a/crm.py
+++ b/crm.py
@@ -272,7 +272,7 @@ class CrmCase(osv.osv):
             case_id = case_id[0]
         watchers_bcc = self.read(
             cursor, uid, [case_id], ['email_bcc'], context=context
-        )[0]['email_bcc']
+        )[0]['email_bcc'] or ''
         watchers_bcc = [e.strip() for e in watchers_bcc.split(',') if e]
         emails = super(CrmCase, self).get_bcc_emails(
             cursor, uid, case_id, context=context)

--- a/crm.py
+++ b/crm.py
@@ -270,9 +270,10 @@ class CrmCase(osv.osv):
             context = {}
         if isinstance(case_id, (list, tuple)):
             case_id = case_id[0]
-        watchers_bcc = (self.read(
+        watchers_bcc = self.read(
             cursor, uid, [case_id], ['email_bcc'], context=context
-        )[0]['email_bcc'] or '').split(', ')
+        )[0]['email_bcc']
+        watchers_bcc = [e.strip() for e in watchers_bcc.split(',') if e]
         emails = super(CrmCase, self).get_bcc_emails(
             cursor, uid, case_id, context=context)
         return list(set(emails+watchers_bcc+context.get('email_bcc', [])))

--- a/crm_data.xml
+++ b/crm_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
-    <data noupdate="1">
+    <data noupdate="0">
         <!-- CRM Poweremail - Templates -->
         <record model="poweremail.templates" id="crm_poweremail_case_template_new">
             <field name="name">New Case Template</field>
@@ -14,7 +14,8 @@
             <field name="lang" eval="False"/>
             <field name="def_body_text">
 In date ${date_now} we have recieved the case with the subject: ${object.name}
-Case Identifier: #${object.id}
+
+- Case Identifier: #${object.id}
 
 Waiting for a responsible to take over the case.
 
@@ -32,9 +33,9 @@ Waiting for a responsible to take over the case.
             <field name="use_sign" eval="False"/>
             <field name="def_body_text">
 In date ${date_now} the case has been Opened with the subject: ${object.name}
-Case Identifier: #${object.id}
 
-Responsible: ${object.user_id.name} &lt;${object.user_id.address_id.email}&gt;
+- Case Identifier: #${object.id}
+- Responsible: ${object.user_id.name} &lt;${object.user_id.address_id.email}&gt;
 
             </field>
         </record>

--- a/crm_data.xml
+++ b/crm_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
-    <data noupdate="0">
+    <data noupdate="1">
         <!-- CRM Poweremail - Templates -->
         <record model="poweremail.templates" id="crm_poweremail_case_template_new">
             <field name="name">New Case Template</field>
@@ -75,7 +75,7 @@ The case with identifier: #${object.id} with the subject: "${object.name}" has b
         <!-- CRM - Rules -->
         <record model="crm.case.rule" id="crm_poweremail_rule_new">
             <field name="name">Poweremail New Case</field>
-            <field name="active">True</field>
+            <field name="active" eval="False"/>
             <field name="trg_state_from">draft</field>
             <field name="trg_min_history" eval="0"/>
             <field name="trg_max_history_log" eval="1"/>
@@ -84,7 +84,7 @@ The case with identifier: #${object.id} with the subject: "${object.name}" has b
 
         <record model="crm.case.rule" id="crm_poweremail_rule_open">
             <field name="name">Poweremail Open Case</field>
-            <field name="active">True</field>
+            <field name="active" eval="False"/>
             <field name="trg_state_from">draft</field>
             <field name="trg_state_to">open</field>
             <field name="pm_template_id" ref="crm_poweremail_case_template_open"/>
@@ -95,7 +95,7 @@ The case with identifier: #${object.id} with the subject: "${object.name}" has b
 
         <record model="crm.case.rule" id="crm_poweremail_rule_pending">
             <field name="name">Poweremail Pending Case</field>
-            <field name="active">True</field>
+            <field name="active" eval="False"/>
             <field name="trg_state_from">open</field>
             <field name="trg_state_to">pending</field>
             <field name="pm_template_id" ref="crm_poweremail_case_template_pending"/>
@@ -106,7 +106,7 @@ The case with identifier: #${object.id} with the subject: "${object.name}" has b
 
         <record model="crm.case.rule" id="crm_poweremail_rule_close">
             <field name="name">Poweremail Close Case</field>
-            <field name="active">True</field>
+            <field name="active" eval="False"/>
             <field name="trg_state_from">pending</field>
             <field name="trg_state_to">done</field>
             <field name="pm_template_id" ref="crm_poweremail_case_template_close"/>

--- a/crm_demo.xml
+++ b/crm_demo.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data>
-        <record model="crm.case.rule" id="crm_poweremail_rule_new">
-            <field name="active" eval="False"/>
-        </record>
         <record id="crmpoweremail_pem_account01" model="poweremail.core_accounts">
             <field name="name">Test Account</field>
             <field name="email_id">test@example.com</field>

--- a/crm_demo.xml
+++ b/crm_demo.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data>
+        <record model="crm.case.rule" id="crm_poweremail_rule_new">
+            <field name="active" eval="False"/>
+        </record>
         <record id="crmpoweremail_pem_account01" model="poweremail.core_accounts">
             <field name="name">Test Account</field>
             <field name="email_id">test@example.com</field>

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -214,7 +214,7 @@ class PoweremailMailboxCRM(osv.osv):
         case_obj = self.pool.get('crm.case')
         mailbox_obj = self.pool.get('poweremail.mailbox')
         email_from = case.section_id.reply_to
-        email_to = case_obj.filter_emails(
+        email_to = case_obj.filter_mails(
             (
                 case.get_cc_emails() +
                 [case.user_id.address_id.email, case.partner_address_id.email]
@@ -223,7 +223,7 @@ class PoweremailMailboxCRM(osv.osv):
             case,
             todel_emails=email.recipients.addresses+[case.section_id.reply_to]
         )
-        email_bcc = case_obj.filter_emails(
+        email_bcc = case_obj.filter_mails(
             case.get_bcc_emails(),
             email.from_.address,
             case,
@@ -251,7 +251,7 @@ class PoweremailMailboxCRM(osv.osv):
                 'conversation_id': case.conversation_id.id,
             }
             mailbox_obj.create(cursor, uid, vals_forward, context=context)
-        elif email_bcc:
+        if email_bcc:
             p_mail = self.browse(cursor, uid, pmail_id, context=context)
             for bcc in email_bcc:
                 vals_forward = {
@@ -311,6 +311,7 @@ class PoweremailMailboxCRM(osv.osv):
                 self.update_case_from_mail(
                     cursor, uid, p_mail.id, case_id, mail, context=context
                 )
+                # Reread case
                 case = case_obj.browse(cursor, uid, case_id[0], context=context)
                 self.forward_case_response(
                     cursor, uid, p_mail.id, case, mail, context=context


### PR DESCRIPTION
## PRE

- Tests fails on creating demo data as the rules do trigger and no account is set
- Getting bcc emails fails due to not parsing read result
- Case-Related-Attachment getting fails due to no correctly reading the IDs
- The emails were not being forwarded as the method calls an unexistent method
- The filter_emails used on email forwarding does not filter by email address, allowing multiple emails to the same address with different display names.

## POST

- Test won't fail as rules are created but disabled by default (`active = False`)
- BCC Emails getter won't fail. Now parses the Emails as on oficial/crm
- Case-Related-Attachment won't fail. 
  - Now search from the attachment model instead poweremail.
  - Now uses search with "`res_id in list`" instead of `for each id, read and search`
- The emails are forwarded as they call the `filter_mails` method that does exist in CRM-Case
- The filter_emails does filter by email address