### PR TITLE
Add to watchers when updating from email

### DIFF
--- a/crm.py
+++ b/crm.py
@@ -111,12 +111,18 @@ class CrmCase(osv.osv):
             case_ids = [case_ids]
         if not isinstance(address_ids, (tuple, list)):
             address_ids = [address_ids]
+        pwmail_obj = self.pool.get('poweremail.mailbox')
         case_obj = self.pool.get('crm.case')
         addr_obj = self.pool.get('res.partner.address')
         # Get Field Name according to BCC parameter
         fieldname = '{}_address_ids'.format(
             'bcc' if bcc else 'cc'
         )
+        # Get address_ids from email address on context
+        if not address_ids and context.get('watcher_email', False):
+            email_addr = context.get('watcher_email', False)
+            address_ids = pwmail_obj.get_partner_address_from_email(
+                cursor, uid, email_addr)
         # Filter addresses that have email
         address_ids = [
             aid['id']

--- a/crm.py
+++ b/crm.py
@@ -130,6 +130,9 @@ class CrmCase(osv.osv):
                 cursor, uid, address_ids, ['email'], context=context)
             if aid['email']
         ]
+        # Abort if no ids after filtering
+        if not address_ids:
+            return
         # Add the addresses to each case in IDS parameter
         for case_id in case_ids:
             case_addrs = case_obj.read(

--- a/crm.py
+++ b/crm.py
@@ -111,18 +111,12 @@ class CrmCase(osv.osv):
             case_ids = [case_ids]
         if not isinstance(address_ids, (tuple, list)):
             address_ids = [address_ids]
-        pwmail_obj = self.pool.get('poweremail.mailbox')
         case_obj = self.pool.get('crm.case')
         addr_obj = self.pool.get('res.partner.address')
         # Get Field Name according to BCC parameter
         fieldname = '{}_address_ids'.format(
             'bcc' if bcc else 'cc'
         )
-        # Get address_ids from email address on context
-        if not address_ids and context.get('watcher_email', False):
-            email_addr = context.get('watcher_email', False)
-            address_ids = pwmail_obj.get_partner_address_from_email(
-                cursor, uid, email_addr)
         # Filter addresses that have email
         address_ids = [
             aid['id']

--- a/crm_view.xml
+++ b/crm_view.xml
@@ -13,6 +13,9 @@
                         <button name="autowatch" string="Watch this case" type="object"/>
                     </group>
                 </xpath>
+                <!-- Remove old Email_CC -->
+                <xpath expr="//field[@name='email_cc']" position="replace"></xpath>
+                <!-- ADD Watchers -->
             	<page string="History" position="before">
             		<page string="Conversations">
             			<field name="conversation_mails" nolabel="1" colspan="4" />

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -3,7 +3,7 @@ from osv import osv
 from tools.translate import _
 from talon import quotations
 from datetime import datetime
-from email.utils import make_msgid
+from qreu.address import Address
 
 import qreu
 
@@ -13,6 +13,41 @@ class PoweremailMailboxCRM(osv.osv):
     """
     _name = 'poweremail.mailbox'
     _inherit = 'poweremail.mailbox'
+
+    def get_partner_address_from_email(self, cursor, uid, email_address):
+        """
+        Gets or Creates the 'res.partner.address' from a poweremail_mailbox from
+        :param cursor:      OpenERP Cursor
+        :param uid:         OpenERP User ID
+        :type uid:          int
+        :param email:       Email address
+        :type email:        str
+        :return:            Res.Partner.Address (browsed)
+        :rtype:             osv.osv
+        """
+        address_obj = self.pool.get('res.partner.address')
+        partner_obj = self.pool.get('res.partner')
+        email = Address.parse(email_address)
+        address_id = address_obj.search(cursor, uid, [
+            ('email', 'ilike', email.address)
+        ])
+        if address_id:
+            return address_id[0]
+        else:
+            # If not found: create partner address
+            address_id = address_obj.create(cursor, uid, {
+                'name': email.display_name,
+                'email': email.address,
+            })
+            domain = email.address.split('@')[-1].strip()
+            partner_id = partner_obj.search(
+                cursor, uid, [('domain', '=', domain)]
+            )
+            if partner_id:
+                address_obj.write(
+                    cursor, uid, address_id, {'partner_id': partner_id[0]}
+                )
+        return address_id
 
     def get_partner_address(self, cursor, uid, p_mail_id):
         """
@@ -26,40 +61,12 @@ class PoweremailMailboxCRM(osv.osv):
         :rtype:             osv.osv
         """
         address_obj = self.pool.get('res.partner.address')
-        partner_obj = self.pool.get('res.partner')
         p_mail = self.pool.get('poweremail.mailbox').read(
             cursor, uid, p_mail_id, ['pem_mail_orig', 'pem_from']
         )
         mail = qreu.Email.parse(p_mail['pem_mail_orig'])
-        try:
-            address_id = address_obj.search(cursor, uid, [
-                ('email', '=', mail.from_.address)
-            ])
-        except Exception as err:
-            import logging
-            logging.getLogger('poweremail.mailbox').error(
-                _('Could not parse poweremail_mailbox '
-                  'pem_from address with qreu')
-            )
-            return False
-        if address_id:
-            address_id = address_id[0]
-        else:
-            # If not found: create partner address
-            address_email = mail.from_.address
-            address_name = mail.from_.display_name or address_email
-            address_id = address_obj.create(cursor, uid, {
-                'name': address_name,
-                'email': address_email
-            })
-            domain = address_email.split('@')[-1].strip()
-            partner_id = partner_obj.search(
-                cursor, uid, [('domain', '=', domain)]
-            )
-            if partner_id:
-                address_obj.write(
-                    cursor, uid, address_id, {'partner_id': partner_id[0]}
-                )
+        address_id = self.get_partner_address_from_email(cursor, uid,
+                                                         mail.from_.display)
         return address_obj.browse(cursor, uid, address_id) or False
 
     def create_crm_case(self, cursor, uid, p_mail_id, section_id,


### PR DESCRIPTION
When recieving an email, use the "add_to_watchers" method to add all addresses of the email (FROM/TO/CC) to the "watchers_cc" field on the case.

Instead of the current usage (append the addresses as they are recieved), get the `res.partner.address` or create one if not found.

