### PR TITLE
Fix reading case with ID instead of List

### DIFF
--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -166,7 +166,7 @@ class PoweremailMailboxCRM(osv.osv):
             _('Reply'), history=True, email=email.from_.address
         )
         # 3.- Emails from CC, TO and FROM
-        case_data = case_obj.read(cursor, uid, [case_id], ['section_id'])
+        case_data = case_obj.read(cursor, uid, case_id, ['section_id'])
         reply_to = section_obj.read(
             cursor, uid, case_data['section_id'][0], ['reply_to']
         )['reply_to']


### PR DESCRIPTION
Fixes update case from email method.

It was expecting a dictionary but it was a list of dictionaries as we were reading using the Case ID in a List.