### PR TITLE
Añadir paquete regex en requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Mako
+regex==2017.9.23
 talon
 qreu>=0.10.0
 markdown


### PR DESCRIPTION
Se a añadido el paquete regex en requirements.txt porque es una dependencia del paquete talon del mismo fichero