### PR TITLE
Corrección en la obtención de la dirección del remitente en los emails antes de crear los SAC

### DIFF
--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -85,7 +85,7 @@ class PoweremailMailboxCRM(osv.osv):
         )
         mail = qreu.Email.parse(p_mail['pem_mail_orig'])
         address_id = self.get_partner_address_from_email(cursor, uid,
-                                                         mail.from_.display)
+                                                         mail.from_.address)
         return address_obj.browse(cursor, uid, address_id) or False
 
     def create_crm_case(self, cursor, uid, p_mail_id, section_id,


### PR DESCRIPTION
## Objetivos

- Arreglar la obtención de la dirección e-mail del remitente de un mensaje, para que se pueda crear el SAC correspondiente buscando la dirección de empresa en el ERP.

