### PR TITLE
Revert https://github.com/gisce/crm_poweremail/pull/66

### DIFF
--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -85,7 +85,7 @@ class PoweremailMailboxCRM(osv.osv):
         )
         mail = qreu.Email.parse(p_mail['pem_mail_orig'])
         address_id = self.get_partner_address_from_email(cursor, uid,
-                                                         mail.from_.address)
+                                                         mail.from_.display)
         return address_obj.browse(cursor, uid, address_id) or False
 
     def create_crm_case(self, cursor, uid, p_mail_id, section_id,


### PR DESCRIPTION
display name should be used when searching for a partner. The name is empty when `address` attribute is used.

needs: https://github.com/gisce/qreu/pull/53