### PR TITLE
Incrementar la capacitat del les direccions en còpia oculta

### DIFF
--- a/crm.py
+++ b/crm.py
@@ -507,7 +507,7 @@ class CrmCase(osv.osv):
             obj='poweremail.mailbox',
             method=True
         ),
-        'email_bcc': fields.char('Secret Watchers Emails', size=252),
+        'email_bcc': fields.char('Secret Watchers Emails', size=1000),
         'cc_address_ids': fields.many2many(
             obj='res.partner.address', rel='crm_case_watchers_address',
             id1='case_id', id2='address_id', string='Watchers Addresses (CC)'

--- a/crm.py
+++ b/crm.py
@@ -507,7 +507,7 @@ class CrmCase(osv.osv):
             obj='poweremail.mailbox',
             method=True
         ),
-        'email_bcc': fields.char('Secret Watchers Emails', size=1000),
+        'email_bcc': fields.char('Secret Watchers Emails', size=2000),
         'cc_address_ids': fields.many2many(
             obj='res.partner.address', rel='crm_case_watchers_address',
             id1='case_id', id2='address_id', string='Watchers Addresses (CC)'

--- a/migrations/5.0.26.1.0/post-0001_increase_bcc_email_size.py
+++ b/migrations/5.0.26.1.0/post-0001_increase_bcc_email_size.py
@@ -6,8 +6,6 @@ def up(cursor, installed_version):
     if not installed_version:
         return
 
-    module = 'crm_poweremail'
-    mh = MigrationHelper(cursor, module)
     sql = """
         ALTER TABLE crm_case
             ALTER COLUMN email_bcc TYPE varchar(1000);

--- a/migrations/5.0.26.1.0/post-0001_increase_bcc_email_size.py
+++ b/migrations/5.0.26.1.0/post-0001_increase_bcc_email_size.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from oopgrade.oopgrade import MigrationHelper
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    module = 'crm_poweremail'
+    mh = MigrationHelper(cursor, module)
+    sql = """
+        ALTER TABLE crm_case
+            ALTER COLUMN email_bcc TYPE varchar(1000);
+    """
+    cursor.execute(sql)
+
+    return True
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up
+

--- a/migrations/5.0.26.1.0/post-0001_increase_bcc_email_size.py
+++ b/migrations/5.0.26.1.0/post-0001_increase_bcc_email_size.py
@@ -8,7 +8,7 @@ def up(cursor, installed_version):
 
     sql = """
         ALTER TABLE crm_case
-            ALTER COLUMN email_bcc TYPE varchar(1000);
+            ALTER COLUMN email_bcc TYPE varchar(2000);
     """
     cursor.execute(sql)
 


### PR DESCRIPTION
## Comportament nou
Es permet posar i mostrar més emails.

<img width="1446" height="803" alt="image" src="https://github.com/user-attachments/assets/618c8705-e32b-406d-968b-c7adf82fc723" />


## Comportament antic
Els emails tenien un límit petit de caràcters permesos.

## Relacionat

- Tasca: TASK-77428

### Afectacions / Migració de dades

- [x] **Actualizació mòduls:**
    - _crm_poweremail_
- [x] **Migració de dades**
    - _especificar nom de l'script de migració i a que versió s'executarà_
    - **post-0001_increase_bcc_email_size.py** _('v26.1')_
