### PR TITLE
Corregir el asistente de enviar el caso con un adjunto.

### DIFF
--- a/crm_view.xml
+++ b/crm_view.xml
@@ -14,7 +14,7 @@
                     </group>
                 </xpath>
                 <xpath expr="//button[@name='case_log_reply']" position="replace">
-                    <button name="%(action_wizard_log_reply_attachment_form)d" states="open" string="Send Partner &amp; Historize" type="action"/>
+                    <button name="open_log_reply_attachment" states="open" string="Send Partner &amp; Historize" type="object"/>
                 </xpath>
                 <!-- Remove old Email_CC -->
                 <xpath expr="//field[@name='email_cc']" position="replace"></xpath>

--- a/migrations/5.0.26.5.0/post-0001_update_crm_case_view.py
+++ b/migrations/5.0.26.5.0/post-0001_update_crm_case_view.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from oopgrade.oopgrade import MigrationHelper
+from tools import config
+
+
+def up(cursor, installed_version):
+    if not installed_version or config.updating_all:
+        return
+
+    module = 'crm_poweremail'
+    mh = MigrationHelper(cursor, module)
+
+    file = 'crm_view.xml'
+    views = [
+        'crm_case-view',
+    ]
+    mh.update_xml_records(xml_path=file, init_record_ids=views)
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up


### PR DESCRIPTION
# :warning:
Corregir el asistente de enviar el caso con un adjunto.
## Causa de l'error

> Usaba el active_id en lugar de la id del crm.

## Como reproduir el error

> Usar el asistente 'Send case with attachment' en un modelo que no sea el crm.case

#
- Tasca: TASK-88655

- [x] **Migració de dades**
    - 5.0.26.5.0
    - crm_poweremail   -   post-0001_update_crm_case_view.py
