### PR TITLE
Mostrar imatges inline al cos del correu

### DIFF
--- a/crm_data.xml
+++ b/crm_data.xml
@@ -121,5 +121,10 @@ The case with identifier: #${object.id} with the subject: "${object.name}" has b
             <field name="value">20</field>
             <field name="description">Max size of attachments to send attachments</field>
         </record>
+        <record model="res.config" id="crm_poweremail_markdown_inline_images" forcecreate="1">
+            <field name="name">crm_poweremail_markdown_inline_images</field>
+            <field name="value">0</field>
+            <field name="description">Convert incoming CRM HTML mail bodies to Markdown with inline attachment images</field>
+        </record>
     </data>
 </openerp>

--- a/crm_view.xml
+++ b/crm_view.xml
@@ -16,6 +16,9 @@
                 <xpath expr="//button[@name='case_log_reply']" position="replace">
                     <button name="open_log_reply_attachment" states="open" string="Send Partner &amp; Historize" type="object"/>
                 </xpath>
+                <xpath expr="//button[@name='case_log_reply']/preceding-sibling::field[@name='description'][1]" position="attributes">
+                    <attribute name="widget">markdown_editor</attribute>
+                </xpath>
                 <!-- Remove old Email_CC -->
                 <xpath expr="//field[@name='email_cc']" position="replace"></xpath>
                 <!-- ADD Watchers -->

--- a/crm_view.xml
+++ b/crm_view.xml
@@ -16,7 +16,7 @@
                 <xpath expr="//button[@name='case_log_reply']" position="replace">
                     <button name="open_log_reply_attachment" states="open" string="Send Partner &amp; Historize" type="object"/>
                 </xpath>
-                <xpath expr="//button[@name='case_log_reply']/preceding-sibling::field[@name='description'][1]" position="attributes">
+                <xpath expr="//field[@name='description']" position="attributes">
                     <attribute name="widget">markdown_editor</attribute>
                 </xpath>
                 <!-- Remove old Email_CC -->

--- a/crm_view.xml
+++ b/crm_view.xml
@@ -16,7 +16,7 @@
                 <xpath expr="//button[@name='case_log_reply']" position="replace">
                     <button name="open_log_reply_attachment" states="open" string="Send Partner &amp; Historize" type="object"/>
                 </xpath>
-                <xpath expr="//field[@name='description']" position="attributes">
+                <xpath expr="(//field[@name='description'])[2]" position="attributes">
                     <attribute name="widget">markdown_editor</attribute>
                 </xpath>
                 <!-- Remove old Email_CC -->

--- a/demo/crm_demo.xml
+++ b/demo/crm_demo.xml
@@ -12,5 +12,44 @@
         <record model="ir.attachment" id="poweremail.attachment_associated_to_filter_2">
             <field name="category_id" ref="base_extended.attachment_category_temporal_3_weeks"/>
         </record>
+
+        <record model="poweremail.conversation" id="crm_poweremail_inline_image_conversation">
+            <field name="name">Demo inline image in CRM case body</field>
+        </record>
+
+        <record model="poweremail.mailbox" id="crm_poweremail_inline_image_mailbox">
+            <field name="pem_account_id" ref="poweremail.info_energia_from_email"/>
+            <field name="pem_message_id">&lt;demo-inline-image@crm-poweremail&gt;</field>
+            <field name="pem_from">client.demo@example.com</field>
+            <field name="pem_to">test@example.com</field>
+            <field name="pem_subject">Demo: imatge inline al CRM</field>
+            <field name="pem_body_text">Correu entrant demo amb imatge inline.</field>
+            <field name="state">read</field>
+            <field name="folder">inbox</field>
+            <field name="conversation_id" ref="crm_poweremail_inline_image_conversation"/>
+        </record>
+
+        <record model="ir.attachment" id="crm_poweremail_inline_image_attachment">
+            <field name="name">demo-inline-image.png</field>
+            <field name="datas_fname">demo-inline-image.png</field>
+            <field name="res_model">poweremail.mailbox</field>
+            <field name="res_id" ref="crm_poweremail_inline_image_mailbox"/>
+            <field name="datas">iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=</field>
+        </record>
+
+        <record model="poweremail.mailbox" id="crm_poweremail_inline_image_mailbox">
+            <field name="pem_attachments_ids" eval="[(6, 0, [ref('crm_poweremail_inline_image_attachment')])]"/>
+        </record>
+
+        <record model="crm.case" id="crm_poweremail_inline_image_case">
+            <field name="name">Demo: imatge inline al cos del correu</field>
+            <field name="section_id" ref="crm.crm_custom_service_section"/>
+            <field name="active" eval="True"/>
+            <field name="user_id" ref="base.user_demo"/>
+            <field name="partner_id" ref="base.main_partner"/>
+            <field name="email_from">client.demo@example.com</field>
+            <field name="conversation_id" ref="crm_poweremail_inline_image_conversation"/>
+            <field name="description" eval="'**Correu entrant demo amb imatge inline**\n\nHola **CRM**, aquesta imatge hauria de renderitzar-se dins el cos del missatge:\n\n![Logo demo](attachment://%s)\n\nText final del correu.' % ref('crm_poweremail_inline_image_attachment')"/>
+        </record>
     </data>
 </openerp>

--- a/demo/crm_demo.xml
+++ b/demo/crm_demo.xml
@@ -5,14 +5,6 @@
             <field name="conversation_id" ref="poweremail.poweremail_conversation_1"/>
             <field name="email_bcc">test@mail.com, test@example.com</field>
         </record>
-
-        <record model="ir.attachment" id="poweremail.attachment_associated_to_filter_1">
-            <field name="category_id" ref="base_extended.attachment_category_temporal_1_month"/>
-        </record>
-        <record model="ir.attachment" id="poweremail.attachment_associated_to_filter_2">
-            <field name="category_id" ref="base_extended.attachment_category_temporal_3_weeks"/>
-        </record>
-
         <record model="poweremail.conversation" id="crm_poweremail_inline_image_conversation">
             <field name="name">Demo inline image in CRM case body</field>
         </record>

--- a/migrations/5.0.26.5.0/post-0002_update_crm_case_markdown_editor.py
+++ b/migrations/5.0.26.5.0/post-0002_update_crm_case_markdown_editor.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from oopgrade.oopgrade import MigrationHelper
+from tools import config
+
+
+def up(cursor, installed_version):
+    if not installed_version or config.updating_all:
+        return
+
+    module = 'crm_poweremail'
+    mh = MigrationHelper(cursor, module)
+
+    mh.update_xml_records(
+        xml_path='crm_view.xml',
+        init_record_ids=['crm_case-view'],
+    )
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/migrations/5.0.26.5.0/post-0002_update_crm_case_markdown_editor.py
+++ b/migrations/5.0.26.5.0/post-0002_update_crm_case_markdown_editor.py
@@ -16,6 +16,10 @@ def up(cursor, installed_version):
         xml_path='crm_view.xml',
         init_record_ids=['crm_case-view'],
     )
+    mh.update_xml_records(
+        xml_path='crm_data.xml',
+        init_record_ids=['crm_poweremail_markdown_inline_images'],
+    )
 
 
 def down(cursor, installed_version):

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -18,6 +18,10 @@ import qreu
 
 
 CASE_ID_RE = re.compile(r"<.*tinycrm-(\d+)@.*>", re.UNICODE)
+MARKDOWN_EMAIL_AUTOLINK_RE = re.compile(
+    r'<(mailto:)?([A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,})>',
+    re.IGNORECASE | re.UNICODE
+)
 
 try:
     basestring
@@ -98,6 +102,12 @@ def _replace_inline_image_sources(html_body, attachment_map):
         for child in fragment
     ])
     return ''.join(parts)
+
+
+def _escape_mdx_email_autolinks(markdown_body):
+    if not markdown_body:
+        return markdown_body
+    return MARKDOWN_EMAIL_AUTOLINK_RE.sub(r'\2', markdown_body)
 
 
 class PoweremailMailboxCRM(osv.osv):
@@ -295,7 +305,7 @@ class PoweremailMailboxCRM(osv.osv):
             html_body = _replace_inline_image_sources(
                 html_body, attachment_map
             )
-            return html2text(html_body).strip()
+            return _escape_mdx_email_autolinks(html2text(html_body).strip())
         return p_mail.pem_body_text or mail.body_parts.get('plain') or ''
 
     def _markdown_inline_images_enabled(self, cursor, uid):

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -9,6 +9,10 @@ from html2text import html2text
 from lxml import html as lxml_html
 import email as email_parser
 import re
+try:
+    from urllib.parse import unquote
+except ImportError:
+    from urllib import unquote
 
 import qreu
 
@@ -35,6 +39,7 @@ def _normalize_attachment_ref(value):
     value = value.strip()
     if value.lower().startswith('cid:'):
         value = value[4:]
+    value = unquote(value)
     return value.strip('<>')
 
 

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -5,6 +5,9 @@ from tools import flatten
 from talon import quotations
 from datetime import datetime
 from qreu.address import Address
+from html2text import html2text
+from lxml import html as lxml_html
+import email as email_parser
 import re
 
 import qreu
@@ -12,11 +15,84 @@ import qreu
 
 CASE_ID_RE = re.compile(r"<.*tinycrm-(\d+)@.*>", re.UNICODE)
 
+try:
+    basestring
+except NameError:
+    basestring = str
+
 
 def get_cases_ids_from_references(references):
     return list({
         int(x) for x in flatten([CASE_ID_RE.findall(ref) for ref in references])
     })
+
+
+def _normalize_attachment_ref(value):
+    if not value:
+        return False
+    if not isinstance(value, basestring):
+        value = str(value)
+    value = value.strip()
+    if value.lower().startswith('cid:'):
+        value = value[4:]
+    return value.strip('<>')
+
+
+def _attachment_ids_from_browse(attachments):
+    return [attachment.id for attachment in attachments]
+
+
+def _build_inline_attachment_map(raw_email, attachments):
+    attachment_ids = _attachment_ids_from_browse(attachments)
+    if not raw_email or not attachment_ids:
+        return {}
+
+    mail_message = email_parser.message_from_string(raw_email)
+    attachment_map = {}
+    part_index = 0
+    for part in mail_message.walk():
+        filename = part.get_filename()
+        if not filename:
+            continue
+        if part_index >= len(attachment_ids):
+            break
+        attachment_id = attachment_ids[part_index]
+        for value in (
+                part.get('Content-ID'),
+                part.get('Content-Location'),
+                filename):
+            key = _normalize_attachment_ref(value)
+            if key:
+                attachment_map[key] = attachment_id
+        part_index += 1
+    return attachment_map
+
+
+def _replace_inline_image_sources(html_body, attachment_map):
+    if not html_body or not attachment_map:
+        return html_body
+    try:
+        fragment = lxml_html.fragment_fromstring(
+            html_body, create_parent='div'
+        )
+    except Exception:
+        return html_body
+
+    changed = False
+    for image in fragment.iter('img'):
+        src = _normalize_attachment_ref(image.get('src'))
+        if src in attachment_map:
+            image.set('src', 'attachment://{0}'.format(attachment_map[src]))
+            changed = True
+
+    if not changed:
+        return html_body
+    parts = [fragment.text or '']
+    parts.extend([
+        lxml_html.tostring(child, encoding='unicode', method='html')
+        for child in fragment
+    ])
+    return ''.join(parts)
 
 
 class PoweremailMailboxCRM(osv.osv):
@@ -205,6 +281,18 @@ class PoweremailMailboxCRM(osv.osv):
             cursor, uid,  case_id, address_ids=addrs_ids
         )
 
+    def _email_body_as_markdown(self, p_mail, mail):
+        html_body = p_mail.pem_body_html or mail.body_parts.get('html')
+        if html_body:
+            attachment_map = _build_inline_attachment_map(
+                p_mail.pem_mail_orig, p_mail.pem_attachments_ids
+            )
+            html_body = _replace_inline_image_sources(
+                html_body, attachment_map
+            )
+            return html2text(html_body).strip()
+        return p_mail.pem_body_text or mail.body_parts.get('plain') or ''
+
     def forward_case_response(
             self, cursor, uid, pmail_id, case, email, context=None):
         """
@@ -293,6 +381,12 @@ class PoweremailMailboxCRM(osv.osv):
             mail = qreu.Email.parse(p_mail.pem_mail_orig)
             if mail.is_auto_generated:
                 return res_id
+            body_markdown = self._email_body_as_markdown(p_mail, mail)
+            if body_markdown and body_markdown != p_mail.pem_body_text:
+                self.write(cursor, uid, [res_id], {
+                    'pem_body_text': body_markdown
+                }, context=context)
+                p_mail = self.browse(cursor, uid, res_id, context=context)
             reply_to = [x.lower() for x in mail.recipients.addresses]
         else:
             # If no mail source found, the mail is being sent

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -298,6 +298,12 @@ class PoweremailMailboxCRM(osv.osv):
             return html2text(html_body).strip()
         return p_mail.pem_body_text or mail.body_parts.get('plain') or ''
 
+    def _markdown_inline_images_enabled(self, cursor, uid):
+        conf_obj = self.pool.get('res.config')
+        return bool(int(conf_obj.get(
+            cursor, uid, 'crm_poweremail_markdown_inline_images', 0
+        )))
+
     def forward_case_response(
             self, cursor, uid, pmail_id, case, email, context=None):
         """
@@ -401,12 +407,13 @@ class PoweremailMailboxCRM(osv.osv):
                 # Ignore mails sent FROM this section
                 return res_id
 
-            body_markdown = self._email_body_as_markdown(p_mail, mail)
-            if body_markdown and body_markdown != p_mail.pem_body_text:
-                self.write(cursor, uid, [res_id], {
-                    'pem_body_text': body_markdown
-                }, context=context)
-                p_mail = self.browse(cursor, uid, res_id, context=context)
+            if self._markdown_inline_images_enabled(cursor, uid):
+                body_markdown = self._email_body_as_markdown(p_mail, mail)
+                if body_markdown and body_markdown != p_mail.pem_body_text:
+                    self.write(cursor, uid, [res_id], {
+                        'pem_body_text': body_markdown
+                    }, context=context)
+                    p_mail = self.browse(cursor, uid, res_id, context=context)
 
             cases_ids = case_obj.search(cursor, uid, [
                 ('conversation_id', '=', p_mail.conversation_id.id)

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -386,12 +386,6 @@ class PoweremailMailboxCRM(osv.osv):
             mail = qreu.Email.parse(p_mail.pem_mail_orig)
             if mail.is_auto_generated:
                 return res_id
-            body_markdown = self._email_body_as_markdown(p_mail, mail)
-            if body_markdown and body_markdown != p_mail.pem_body_text:
-                self.write(cursor, uid, [res_id], {
-                    'pem_body_text': body_markdown
-                }, context=context)
-                p_mail = self.browse(cursor, uid, res_id, context=context)
             reply_to = [x.lower() for x in mail.recipients.addresses]
         else:
             # If no mail source found, the mail is being sent
@@ -406,6 +400,13 @@ class PoweremailMailboxCRM(osv.osv):
             if mail.from_.address == section.reply_to:
                 # Ignore mails sent FROM this section
                 return res_id
+
+            body_markdown = self._email_body_as_markdown(p_mail, mail)
+            if body_markdown and body_markdown != p_mail.pem_body_text:
+                self.write(cursor, uid, [res_id], {
+                    'pem_body_text': body_markdown
+                }, context=context)
+                p_mail = self.browse(cursor, uid, res_id, context=context)
 
             cases_ids = case_obj.search(cursor, uid, [
                 ('conversation_id', '=', p_mail.conversation_id.id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ cchardet>=2.2.0a2;python_version>"2.7.18"
 talon
 qreu>=0.10.0
 markdown
+html2text
+lxml<5.0.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -496,6 +496,66 @@ class TestCRMPoweremail(testing.OOTestCase):
             self.assertEqual(p_mail.pem_body_text, 'fallback text')
             self.assertEqual(kwargs['body_text'], 'fallback text')
 
+    def test_incoming_html_email_autolinks_are_mdx_safe(self):
+        """Test Markdown email autolinks do not break the MDX editor."""
+        self.logger.info('Testing incoming email autolinks are MDX safe')
+        from mock import patch
+
+        conf_obj = self.pool.get('res.config')
+        mailbox_obj = self.pool.get('poweremail.mailbox')
+        conv_obj = self.pool.get('poweremail.conversation')
+        account_obj = self.pool.get('poweremail.core_accounts')
+
+        account_id = account_obj.create(self.cursor, self.uid, {
+            'name': 'Test Account Email Autolinks',
+            'email_id': 'section@example.com',
+            'user': self.uid,
+            'smtpserver': 'smtp.example.com',
+            'smtpport': 587,
+            'company': 'no',
+        })
+        conv_id = conv_obj.create(self.cursor, self.uid, {
+            'name': 'Email Autolink Conversation'
+        })
+        html_body = (
+            '<html><body><p>Contacte &lt;suport@example.com&gt;</p>'
+            '<p>Resposta del client.</p></body></html>'
+        )
+        raw_email = (
+            'From: newcustomer@example.com\r\n'
+            'To: section@example.com\r\n'
+            'Subject: HTML email autolink\r\n'
+            'MIME-Version: 1.0\r\n'
+            'Content-Type: text/html; charset="utf-8"\r\n'
+            '\r\n'
+            '{0}\r\n'
+        ).format(html_body)
+
+        with conf_obj.ResConfigPatch({
+                'crm_poweremail_markdown_inline_images': '1'
+        }), patch.object(mailbox_obj, 'create_crm_case') as mock_create_case:
+            mailbox_obj.create(self.cursor, self.uid, {
+                'pem_from': 'newcustomer@example.com',
+                'pem_to': 'section@example.com',
+                'pem_subject': 'HTML email autolink',
+                'pem_body_text': 'fallback text',
+                'pem_body_html': html_body,
+                'pem_account_id': account_id,
+                'conversation_id': conv_id,
+                'folder': 'inbox',
+                'pem_mail_orig': raw_email,
+            })
+
+            self.assertTrue(mock_create_case.called)
+            args, kwargs = mock_create_case.call_args
+            pmail_id = args[2]
+            p_mail = mailbox_obj.browse(self.cursor, self.uid, pmail_id)
+            body_text = kwargs['body_text']
+
+            self.assertEqual(p_mail.pem_body_text, body_text)
+            self.assertIn('suport@example.com', body_text)
+            self.assertNotIn('<suport@example.com>', body_text)
+
     def test_non_crm_html_mail_keeps_original_body_text(self):
         """Test HTML conversion does not mutate mail outside CRM sections."""
         self.logger.info('Testing non CRM HTML mail body is not rewritten')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -424,3 +424,64 @@ class TestCRMPoweremail(testing.OOTestCase):
                 body_text
             )
             self.assertFalse(re.search(r'cid:logo%40example.com', body_text))
+
+    def test_non_crm_html_mail_keeps_original_body_text(self):
+        """Test HTML conversion does not mutate mail outside CRM sections."""
+        self.logger.info('Testing non CRM HTML mail body is not rewritten')
+
+        mailbox_obj = self.pool.get('poweremail.mailbox')
+        conv_obj = self.pool.get('poweremail.conversation')
+        account_obj = self.pool.get('poweremail.core_accounts')
+
+        account_id = account_obj.create(self.cursor, self.uid, {
+            'name': 'Test Account Non CRM Inline Images',
+            'email_id': 'other@example.com',
+            'user': self.uid,
+            'smtpserver': 'smtp.example.com',
+            'smtpport': 587,
+            'company': 'no',
+        })
+        conv_id = conv_obj.create(self.cursor, self.uid, {
+            'name': 'Non CRM Inline Image Conversation'
+        })
+        raw_email = (
+            'From: newcustomer@example.com\r\n'
+            'To: other@example.com\r\n'
+            'Subject: HTML non CRM inline image\r\n'
+            'MIME-Version: 1.0\r\n'
+            'Content-Type: multipart/related; boundary="BOUNDARY"\r\n'
+            '\r\n'
+            '--BOUNDARY\r\n'
+            'Content-Type: text/html; charset="utf-8"\r\n'
+            '\r\n'
+            '<html><body><p>Hello <strong>outside CRM</strong></p>'
+            '<p><img alt="Logo" src="cid:logo%40example.com"></p>'
+            '</body></html>\r\n'
+            '--BOUNDARY\r\n'
+            'Content-Type: image/png; name="logo.png"\r\n'
+            'Content-Transfer-Encoding: base64\r\n'
+            'Content-ID: <logo@example.com>\r\n'
+            'Content-Disposition: inline; filename="logo.png"\r\n'
+            '\r\n'
+            'iVBORw0KGgo=\r\n'
+            '--BOUNDARY--\r\n'
+        )
+
+        pmail_id = mailbox_obj.create(self.cursor, self.uid, {
+            'pem_from': 'newcustomer@example.com',
+            'pem_to': 'other@example.com',
+            'pem_subject': 'HTML non CRM inline image',
+            'pem_body_text': 'fallback text',
+            'pem_body_html': (
+                '<html><body><p>Hello <strong>outside CRM</strong></p>'
+                '<p><img alt="Logo" src="cid:logo%40example.com"></p>'
+                '</body></html>'
+            ),
+            'pem_account_id': account_id,
+            'conversation_id': conv_id,
+            'folder': 'inbox',
+            'pem_mail_orig': raw_email,
+        })
+
+        p_mail = mailbox_obj.browse(self.cursor, self.uid, pmail_id)
+        self.assertEqual(p_mail.pem_body_text, 'fallback text')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -356,6 +356,7 @@ class TestCRMPoweremail(testing.OOTestCase):
         self.logger.info('Testing incoming inline images in markdown')
         from mock import patch
 
+        conf_obj = self.pool.get('res.config')
         mailbox_obj = self.pool.get('poweremail.mailbox')
         conv_obj = self.pool.get('poweremail.conversation')
         account_obj = self.pool.get('poweremail.core_accounts')
@@ -394,7 +395,9 @@ class TestCRMPoweremail(testing.OOTestCase):
             '--BOUNDARY--\r\n'
         )
 
-        with patch.object(mailbox_obj, 'create_crm_case') as mock_create_case:
+        with conf_obj.ResConfigPatch({
+                'crm_poweremail_markdown_inline_images': '1'
+        }), patch.object(mailbox_obj, 'create_crm_case') as mock_create_case:
             mailbox_obj.create(self.cursor, self.uid, {
                 'pem_from': 'newcustomer@example.com',
                 'pem_to': 'section@example.com',
@@ -424,6 +427,74 @@ class TestCRMPoweremail(testing.OOTestCase):
                 body_text
             )
             self.assertFalse(re.search(r'cid:logo%40example.com', body_text))
+
+    def test_incoming_html_inline_images_keep_text_by_default(self):
+        """Test HTML conversion is disabled by default for CRM mail."""
+        self.logger.info('Testing incoming inline images opt-in config')
+        from mock import patch
+
+        mailbox_obj = self.pool.get('poweremail.mailbox')
+        conv_obj = self.pool.get('poweremail.conversation')
+        account_obj = self.pool.get('poweremail.core_accounts')
+
+        account_id = account_obj.create(self.cursor, self.uid, {
+            'name': 'Test Account Inline Images Disabled',
+            'email_id': 'section@example.com',
+            'user': self.uid,
+            'smtpserver': 'smtp.example.com',
+            'smtpport': 587,
+            'company': 'no',
+        })
+        conv_id = conv_obj.create(self.cursor, self.uid, {
+            'name': 'Inline Image Disabled Conversation'
+        })
+        raw_email = (
+            'From: newcustomer@example.com\r\n'
+            'To: section@example.com\r\n'
+            'Subject: HTML inline image disabled\r\n'
+            'MIME-Version: 1.0\r\n'
+            'Content-Type: multipart/related; boundary="BOUNDARY"\r\n'
+            '\r\n'
+            '--BOUNDARY\r\n'
+            'Content-Type: text/html; charset="utf-8"\r\n'
+            '\r\n'
+            '<html><body><p>Hello <strong>CRM</strong></p>'
+            '<p><img alt="Logo" src="cid:logo%40example.com"></p>'
+            '</body></html>\r\n'
+            '--BOUNDARY\r\n'
+            'Content-Type: image/png; name="logo.png"\r\n'
+            'Content-Transfer-Encoding: base64\r\n'
+            'Content-ID: <logo@example.com>\r\n'
+            'Content-Disposition: inline; filename="logo.png"\r\n'
+            '\r\n'
+            'iVBORw0KGgo=\r\n'
+            '--BOUNDARY--\r\n'
+        )
+
+        with patch.object(mailbox_obj, 'create_crm_case') as mock_create_case:
+            mailbox_obj.create(self.cursor, self.uid, {
+                'pem_from': 'newcustomer@example.com',
+                'pem_to': 'section@example.com',
+                'pem_subject': 'HTML inline image disabled',
+                'pem_body_text': 'fallback text',
+                'pem_body_html': (
+                    '<html><body><p>Hello <strong>CRM</strong></p>'
+                    '<p><img alt="Logo" src="cid:logo%40example.com"></p>'
+                    '</body></html>'
+                ),
+                'pem_account_id': account_id,
+                'conversation_id': conv_id,
+                'folder': 'inbox',
+                'pem_mail_orig': raw_email,
+            })
+
+            self.assertTrue(mock_create_case.called)
+            args, kwargs = mock_create_case.call_args
+            pmail_id = args[2]
+            p_mail = mailbox_obj.browse(self.cursor, self.uid, pmail_id)
+
+            self.assertEqual(p_mail.pem_body_text, 'fallback text')
+            self.assertEqual(kwargs['body_text'], 'fallback text')
 
     def test_non_crm_html_mail_keeps_original_body_text(self):
         """Test HTML conversion does not mutate mail outside CRM sections."""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,6 +3,7 @@ from destral import testing
 from destral.transaction import Transaction
 
 import logging
+import re
 
 
 class TestCRMPoweremail(testing.OOTestCase):
@@ -349,3 +350,76 @@ class TestCRMPoweremail(testing.OOTestCase):
         case = case_obj.browse(self.cursor, self.uid, case_id)
         cc_addr_ids = [addr.id for addr in case.cc_address_ids]
         self.assertIn(self.test_user_address_id, cc_addr_ids)
+
+    def test_incoming_html_inline_images_are_markdown_attachments(self):
+        """Test incoming HTML images reference saved attachments in markdown."""
+        self.logger.info('Testing incoming inline images in markdown')
+        from mock import patch
+
+        mailbox_obj = self.pool.get('poweremail.mailbox')
+        conv_obj = self.pool.get('poweremail.conversation')
+        account_obj = self.pool.get('poweremail.core_accounts')
+
+        account_id = account_obj.create(self.cursor, self.uid, {
+            'name': 'Test Account Inline Images',
+            'email_id': 'section@example.com',
+            'user': self.uid,
+            'smtpserver': 'smtp.example.com',
+            'smtpport': 587,
+            'company': 'no',
+        })
+        conv_id = conv_obj.create(self.cursor, self.uid, {
+            'name': 'Inline Image Conversation'
+        })
+        raw_email = (
+            'From: newcustomer@example.com\r\n'
+            'To: section@example.com\r\n'
+            'Subject: HTML inline image\r\n'
+            'MIME-Version: 1.0\r\n'
+            'Content-Type: multipart/related; boundary="BOUNDARY"\r\n'
+            '\r\n'
+            '--BOUNDARY\r\n'
+            'Content-Type: text/html; charset="utf-8"\r\n'
+            '\r\n'
+            '<html><body><p>Hello <strong>CRM</strong></p>'
+            '<p><img alt="Logo" src="cid:logo-cid"></p></body></html>\r\n'
+            '--BOUNDARY\r\n'
+            'Content-Type: image/png; name="logo.png"\r\n'
+            'Content-Transfer-Encoding: base64\r\n'
+            'Content-ID: <logo-cid>\r\n'
+            'Content-Disposition: inline; filename="logo.png"\r\n'
+            '\r\n'
+            'iVBORw0KGgo=\r\n'
+            '--BOUNDARY--\r\n'
+        )
+
+        with patch.object(mailbox_obj, 'create_crm_case') as mock_create_case:
+            mailbox_obj.create(self.cursor, self.uid, {
+                'pem_from': 'newcustomer@example.com',
+                'pem_to': 'section@example.com',
+                'pem_subject': 'HTML inline image',
+                'pem_body_text': 'fallback text',
+                'pem_body_html': (
+                    '<html><body><p>Hello <strong>CRM</strong></p>'
+                    '<p><img alt="Logo" src="cid:logo-cid"></p>'
+                    '</body></html>'
+                ),
+                'pem_account_id': account_id,
+                'conversation_id': conv_id,
+                'folder': 'inbox',
+                'pem_mail_orig': raw_email,
+            })
+
+            self.assertTrue(mock_create_case.called)
+            args, kwargs = mock_create_case.call_args
+            pmail_id = args[2]
+            p_mail = mailbox_obj.browse(self.cursor, self.uid, pmail_id)
+            attachment_id = p_mail.pem_attachments_ids[0].id
+            body_text = kwargs['body_text']
+
+            self.assertIn('Hello **CRM**', body_text)
+            self.assertIn(
+                '![Logo](attachment://{0})'.format(attachment_id),
+                body_text
+            )
+            self.assertFalse(re.search(r'cid:logo-cid', body_text))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -382,11 +382,12 @@ class TestCRMPoweremail(testing.OOTestCase):
             'Content-Type: text/html; charset="utf-8"\r\n'
             '\r\n'
             '<html><body><p>Hello <strong>CRM</strong></p>'
-            '<p><img alt="Logo" src="cid:logo-cid"></p></body></html>\r\n'
+            '<p><img alt="Logo" src="cid:logo%40example.com"></p>'
+            '</body></html>\r\n'
             '--BOUNDARY\r\n'
             'Content-Type: image/png; name="logo.png"\r\n'
             'Content-Transfer-Encoding: base64\r\n'
-            'Content-ID: <logo-cid>\r\n'
+            'Content-ID: <logo@example.com>\r\n'
             'Content-Disposition: inline; filename="logo.png"\r\n'
             '\r\n'
             'iVBORw0KGgo=\r\n'
@@ -401,7 +402,7 @@ class TestCRMPoweremail(testing.OOTestCase):
                 'pem_body_text': 'fallback text',
                 'pem_body_html': (
                     '<html><body><p>Hello <strong>CRM</strong></p>'
-                    '<p><img alt="Logo" src="cid:logo-cid"></p>'
+                    '<p><img alt="Logo" src="cid:logo%40example.com"></p>'
                     '</body></html>'
                 ),
                 'pem_account_id': account_id,
@@ -422,4 +423,4 @@ class TestCRMPoweremail(testing.OOTestCase):
                 '![Logo](attachment://{0})'.format(attachment_id),
                 body_text
             )
-            self.assertFalse(re.search(r'cid:logo-cid', body_text))
+            self.assertFalse(re.search(r'cid:logo%40example.com', body_text))


### PR DESCRIPTION
## Resum
- Converteix el body HTML entrant a Markdown només quan el correu ja ha passat els guards CRM i crearà/actualitzarà un cas.
- Protegeix aquest comportament amb la `res.config` `crm_poweremail_markdown_inline_images`, creada desactivada per defecte (`0`).
- Reescriu imatges inline `cid:` a referencies `attachment://<id>` fent servir els adjunts creats per Poweremail.
- Normalitza `cid:` percent-encoded abans de comparar-los amb `Content-ID` / `Content-Location` MIME.
- Evita que els autolinks Markdown d'email (`<usuari@domini>`) arribin al `markdown_editor`, perquè MDX els interpreta com JSX i pot fallar amb el caràcter `@`.
- Ajusta la vista de `crm.case` perquè l'editor del missatge (`description`) faci servir el widget `markdown_editor`.
- Afegeix una migració `post` que recarrega el registre `crm_case-view` i crea/actualitza la `res.config` `crm_poweremail_markdown_inline_images` a BBDD ja instal·lades.
- Afegeix un registre demo de `crm.case` amb una imatge inline referenciada com `attachment://<id>` per validar visualment el resultat.
- Elimina del demo dues referencies a categories d'adjunt de `base_extended`, perquè `crm_poweremail` no declara aquest mòdul com a dependència.
- Afegeix cobertura amb un correu multipart/related amb imatge inline, el default desactivat, un correu HTML fora de seccions CRM i un correu amb autolink d'email problemàtic per MDX.
- Declara `html2text` i `lxml<5.0.0` com a dependències directes del mòdul.

Refs #79

## Validacio
- `/home/openclaw/.pyenv/versions/erp2/bin/python -m py_compile poweremail_mailbox.py tests/__init__.py` OK
- `/home/openclaw/.pyenv/versions/erp2/bin/python -m py_compile poweremail_mailbox.py crm.py tests/__init__.py tests/test_poweremail_mailbox.py tests/test_crm_case_rule.py` OK
- `/home/openclaw/.pyenv/versions/erp2/bin/python -m py_compile migrations/5.0.26.5.0/post-0002_update_crm_case_markdown_editor.py` OK
- `git diff --check` OK
- XML parse de `crm_data.xml`, `crm_view.xml` i `demo/crm_demo.xml` OK
- XML parse de `crm_view.xml` i XPath contra `crm.crm_case-view`: 1 match sobre el camp `description` editable del missatge
- `/home/openclaw/projects/gisce-developer/env/with-erp-destral-env /home/openclaw/.pyenv/versions/erp2/bin/destral --no-requirements -m crm_poweremail -t TestCRMPoweremail.test_incoming_html_inline_images_are_markdown_attachments -t TestCRMPoweremail.test_incoming_html_inline_images_keep_text_by_default -t TestCRMPoweremail.test_non_crm_html_mail_keeps_original_body_text` OK, 3 tests en 186.719s
- `/home/openclaw/projects/gisce-developer/env/with-erp-destral-env /home/openclaw/.pyenv/versions/erp2/bin/destral --no-requirements -m crm_poweremail -t TestCRMPoweremail.test_onchange_address_ids` OK, 1 test en 305.021s
- `/home/openclaw/projects/gisce-developer/env/with-erp-destral-env /home/openclaw/.pyenv/versions/erp2/bin/destral --no-requirements -m crm_poweremail -t TestCRMPoweremail.test_incoming_html_email_autolinks_are_mdx_safe` OK, 1 test en 143.927s
- `/home/openclaw/projects/gisce-developer/env/with-erp-destral-env /home/openclaw/.pyenv/versions/erp2/bin/destral --no-requirements -m crm_poweremail -t TestCRMPoweremail.test_incoming_html_inline_images_are_markdown_attachments` OK, 1 test en 135.589s
