### PR TITLE
Enviar un correo automáticamente con la notificación de cierre automático de los casos después de 15 días de inactividad

### DIFF
--- a/crm_data.xml
+++ b/crm_data.xml
@@ -72,6 +72,64 @@ The case with identifier: #${object.id} with the subject: "${object.name}" has b
             </field>
         </record>
 
+        <record model="poweremail.templates" id="crm_poweremail_case_template_close_automatically_pending">
+            <field name="name">Close Case Automatically (Pending) Template</field>
+            <field name="object_name" model="ir.model" search="[('model', '=', 'crm.case')]"/>
+            <field name="def_to">${object.email_from}</field>
+            <field name="def_cc">${object.email_cc}</field>
+            <field name="def_bcc">${object.user_id.address_id.email}</field>
+            <field name="def_subject" >${object.name}</field>
+            <field name="lang" >${object.partner_id.lang}</field>
+            <field name="template_language">mako</field>
+            <field name="use_sign" eval="False"/>
+            <field name="def_body_text"><![CDATA[
+<%
+    rule_obj = pool.get('crm.case.rule')
+    imd_obj = pool.get('ir.model.data')
+    rule_id = imd_obj.get_object_reference(cursor, uid, 'crm_poweremail', 'crm_poweremail_rule_auto_close_from_pending')[1]
+    days_passed = int(rule_obj.simple_browse(cursor, uid, rule_id).trg_date_range)
+%>
+
+Hello ${object.partner_id.name},
+
+We closed the case #${object.id} because more than ${days_passed} days have passed without activity.
+
+If the issue is already resolved, you don't need to do anything. If you still need help, please reply to this email.
+
+Best regards,
+The GISCE-TI team
+         ]]></field>
+        </record>
+
+        <record model="poweremail.templates" id="crm_poweremail_case_template_close_automatically_open">
+            <field name="name">Close Case Automatically (Open) Template</field>
+            <field name="object_name" model="ir.model" search="[('model', '=', 'crm.case')]"/>
+            <field name="def_to">${object.email_from}</field>
+            <field name="def_cc">${object.email_cc}</field>
+            <field name="def_bcc">${object.user_id.address_id.email}</field>
+            <field name="def_subject" >${object.name}</field>
+            <field name="lang" >${object.partner_id.lang}</field>
+            <field name="template_language">mako</field>
+            <field name="use_sign" eval="False"/>
+            <field name="def_body_text"><![CDATA[
+<%
+    rule_obj = pool.get('crm.case.rule')
+    imd_obj = pool.get('ir.model.data')
+    rule_id = imd_obj.get_object_reference(cursor, uid, 'crm_poweremail', 'crm_poweremail_rule_auto_close_from_open')[1]
+    days_passed = int(rule_obj.simple_browse(cursor, uid, rule_id).trg_date_range)
+%>
+
+Hello ${object.partner_id.name},
+
+We closed the case #${object.id} because more than ${days_passed} days have passed without activity.
+
+If the issue is already resolved, you don't need to do anything. If you still need help, please reply to this email.
+
+Best regards,
+The GISCE-TI team
+         ]]></field>
+        </record>
+
         <!-- CRM - Rules -->
         <record model="crm.case.rule" id="crm_poweremail_rule_new">
             <field name="name">Poweremail New Case</field>
@@ -110,6 +168,34 @@ The case with identifier: #${object.id} with the subject: "${object.name}" has b
             <field name="trg_state_from">pending</field>
             <field name="trg_state_to">done</field>
             <field name="pm_template_id" ref="crm_poweremail_case_template_close"/>
+            <field name="act_mail_to_email" eval=""/>
+            <field name="act_mail_to_user" eval="True"/>
+            <field name="act_mail_to_partner" eval="True"/>
+        </record>
+
+        <record model="crm.case.rule" id="crm_poweremail_rule_auto_close_from_pending">
+            <field name="name">Poweremail Automatically Close Case (from pending)</field>
+            <field name="active" eval="False"/>
+            <field name="trg_state_from">pending</field>
+            <field name="trg_state_to">done</field>
+            <field name="trg_date_range">15</field>
+            <field name="trg_date_range_type">day</field>
+            <field name="trg_pending_client_reply" eval="True"/>
+            <field name="pm_template_id" ref="crm_poweremail_case_template_close_automatically_pending"/>
+            <field name="act_mail_to_email" eval=""/>
+            <field name="act_mail_to_user" eval="True"/>
+            <field name="act_mail_to_partner" eval="True"/>
+        </record>
+
+        <record model="crm.case.rule" id="crm_poweremail_rule_auto_close_from_open">
+            <field name="name">Poweremail Automatically Close Case (from open)</field>
+            <field name="active" eval="False"/>
+            <field name="trg_state_from">open</field>
+            <field name="trg_state_to">done</field>
+            <field name="trg_date_range">15</field>
+            <field name="trg_date_range_type">day</field>
+            <field name="trg_pending_client_reply" eval="True"/>
+            <field name="pm_template_id" ref="crm_poweremail_case_template_close_automatically_open"/>
             <field name="act_mail_to_email" eval=""/>
             <field name="act_mail_to_user" eval="True"/>
             <field name="act_mail_to_partner" eval="True"/>

--- a/crm_data.xml
+++ b/crm_data.xml
@@ -177,7 +177,8 @@ The GISCE-TI team
             <field name="name">Poweremail Automatically Close Case (from pending)</field>
             <field name="active" eval="False"/>
             <field name="trg_state_from">pending</field>
-            <field name="trg_state_to">done</field>
+            <field name="act_state">done</field>
+            <field name="trg_date_type">action_last</field>
             <field name="trg_date_range">15</field>
             <field name="trg_date_range_type">day</field>
             <field name="trg_pending_client_reply" eval="True"/>
@@ -191,7 +192,8 @@ The GISCE-TI team
             <field name="name">Poweremail Automatically Close Case (from open)</field>
             <field name="active" eval="False"/>
             <field name="trg_state_from">open</field>
-            <field name="trg_state_to">done</field>
+            <field name="act_state">done</field>
+            <field name="trg_date_type">action_last</field>
             <field name="trg_date_range">15</field>
             <field name="trg_date_range_type">day</field>
             <field name="trg_pending_client_reply" eval="True"/>

--- a/i18n/ca_ES.po
+++ b/i18n/ca_ES.po
@@ -2,14 +2,15 @@
 # This file contains the translation of the following modules:
 # 
 # Translators:
+#   <>, 2026.
 # Jaume  Florez Valenzuela <jflorez@gisce.net>, 2017, 2018.
 msgid ""
 msgstr ""
 "Project-Id-Version: GISCE-ERP\n"
 "Report-Msgid-Bugs-To: https://github.com/gisce/erp/issues\n"
-"POT-Creation-Date: 2018-02-20 08:47\n"
-"PO-Revision-Date: 2018-02-21 14:56+0000\n"
-"Last-Translator: Jaume  Florez Valenzuela <jflorez@gisce.net>\n"
+"POT-Creation-Date: 2026-06-22 16:43\n"
+"PO-Revision-Date: 2026-06-22 15:14+0000\n"
+"Last-Translator: destanyol <>\n"
 "Language-Team: Catalan (Spain) <erp@dev.gisce.net>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -32,22 +33,21 @@ msgid ""
 msgstr "\nEl cas amb l'identificador: #${object.id} amb l'assumpte: \"${object.name}\" s'ha TANCAT.\n\n            "
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:237
+#: code:addons/crm_poweremail/crm.py:582
 #, python-format
 msgid "Poweremail template \"Email BCC\" has bad formatted address"
 msgstr "La direcció \"BCC\" de la plantilla Power E-mail no té un format correcte"
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_new
-msgid ""
-"\n"
-"In date ${date_now} we have recieved the case with the subject: ${object.name}\n"
-"Case Identifier: #${object.id}\n"
-"\n"
-"Waiting for a responsible to take over the case.\n"
-"\n"
-"            "
-msgstr "\nEn data ${date_now} hem rebut un cas amb l'assumpte: ${object.name}\n\nIdentificador del cas: #${object.id}\n\nEsperant l'assignació d'un responsable.\n\n                  "
+#: view:crm.case:0
+msgid "Case-Related Attachments"
+msgstr "Adjunts relacionats amb el cas"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:381
+#, python-format
+msgid "Missing Poweremail-Account with Reply-To of the Case Section."
+msgstr "Falta el compte de Poweremail amb Resposta A en la secció del cas."
 
 #. module: crm_poweremail
 #: field:crm.case.rule,pm_template_id:0
@@ -55,7 +55,31 @@ msgid "Poweremail Template"
 msgstr "Plantilla Poweremail"
 
 #. module: crm_poweremail
+#: field:wizard.log.reply.attachment,filename_1:0
+#: field:wizard.log.reply.attachment,filename_2:0
+#: field:wizard.log.reply.attachment,filename_3:0
+#: field:wizard.log.reply.attachment,filename_4:0
+#: field:wizard.log.reply.attachment,filename_5:0
+msgid "Filename"
+msgstr "Nom del fitxer"
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_new
+msgid ""
+"\n"
+"In date ${date_now} we have recieved the case with the subject: ${object.name}\n"
+"\n"
+"- Case Identifier: #${object.id}\n"
+"\n"
+"Waiting for a responsible to take over the case.\n"
+"\n"
+"            "
+msgstr "\nEn data ${date now} hem rebut el cas amb l'assumpte: ${object.name}\n\n- Identificador del cas: #${object.id}\n\nEsperant que un responsable es faci càrrec del cas.\n\n            "
+
+#. module: crm_poweremail
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close_automatically_open
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close_automatically_pending
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_new
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_open
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_pending
@@ -63,11 +87,43 @@ msgid "${object.name}"
 msgstr "${object.name}"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/poweremail_mailbox.py:165
-#: code:addons/crm_poweremail/poweremail_mailbox.py:174
+#: code:addons/crm_poweremail/wizard/wizard_log_reply_with_attachment.py:68
+#, python-format
+msgid "From CRM case [{}] {}"
+msgstr "Del cas CRM [{}] {}"
+
+#. module: crm_poweremail
+#: constraint:ir.actions.act_window:0
+msgid "Invalid model name in the action definition."
+msgstr "Nom de model no vàlid a la definició de l'acció."
+
+#. module: crm_poweremail
+#: view:crm.case:0 field:crm.case,bcc_address_ids:0
+msgid "Secret Watchers Addresses (BCC)"
+msgstr "Adreces dels Observadors Secrets (BCC)"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/poweremail_mailbox.py:176
+#: code:addons/crm_poweremail/poweremail_mailbox.py:187
 #, python-format
 msgid "Reply"
 msgstr "Resposta"
+
+#. module: crm_poweremail
+#: field:crm.case,attachment_ids:0
+msgid "Adjuntos relacionados"
+msgstr "Adjunts relacionats"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:439
+#, python-format
+msgid "You must put a Partner eMail to use this action!"
+msgstr "S'ha d'introduïr el correu electrònic de l'Empresa per poder utilitzar aquesta acció"
+
+#. module: crm_poweremail
+#: view:crm.case:0 field:crm.case,cc_address_ids:0
+msgid "Watchers Addresses (CC)"
+msgstr "Adreces dels observadors (CC)"
 
 #. module: crm_poweremail
 #: view:crm.case:0
@@ -75,9 +131,67 @@ msgid "Conversations"
 msgstr "Converses"
 
 #. module: crm_poweremail
+#: constraint:ir.model:0
+msgid ""
+"The Object name must start with x_ and not contain any special character !"
+msgstr "El nom de l'objecte ha de començar per x_ i no ha de contenir cap caràcter especial!"
+
+#. module: crm_poweremail
 #: field:crm.case,conversation_mails:0
 msgid "unknown"
 msgstr "desconegut"
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close_automatically_open
+msgid ""
+"\n"
+"<%\n"
+"    rule_obj = pool.get('crm.case.rule')\n"
+"    imd_obj = pool.get('ir.model.data')\n"
+"    rule_id = imd_obj.get_object_reference(cursor, uid, 'crm_poweremail', 'crm_poweremail_rule_auto_close_from_open')[1]\n"
+"    days_passed = int(rule_obj.simple_browse(cursor, uid, rule_id).trg_date_range)\n"
+"%>\n"
+"\n"
+"Hello ${object.partner_id.name},\n"
+"\n"
+"We closed the case #${object.id} because more than ${days_passed} days have passed without activity.\n"
+"\n"
+"If the issue is already resolved, you don't need to do anything. If you still need help, please reply to this email.\n"
+"\n"
+"Best regards,\n"
+"The GISCE-TI team\n"
+"         "
+msgstr "\n<%\n    rule_obj = pool.get('crm.case.rule')\n    imd_obj = pool.get('ir.model.data')\n    rule_id = imd_obj.get_object_reference(cursor, uid, 'crm_poweremail', 'crm_poweremail_rule_auto_close_from_open')[1]\n    days_passed = int(rule_obj.simple_browse(cursor, uid, rule_id).trg_date_range)\n%>\n\nHola ${object.partner_id.name},\n\nHem tancat el cas #${object.id} perquè han passat més de ${days_passed} dies sense activitat.\n\nSi el problema ja s'ha resolt, no cal que feu res. Si encara necessiteu ajuda, responeu a aquest correu electrònic.\n\nAtentament,\nL'equip de GISCE-TI\n         "
+
+#. module: crm_poweremail
+#: field:crm.case,email_bcc:0
+msgid "Secret Watchers Emails"
+msgstr "Correus electrònics de Secret Watchers"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:446
+#, python-format
+msgid ""
+"Can not send mail with empty body,you should have description in the body"
+msgstr "No es pot enviar un correu amb el cos buit, hauria d'haver una descripció en el cos del missatge"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:248
+#, python-format
+msgid "You do not have an address!"
+msgstr "No tens adreça!"
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
+msgid ""
+"\n"
+"In date ${date_now} the case has been Opened with the subject: ${object.name}\n"
+"\n"
+"- Case Identifier: #${object.id}\n"
+"- Responsible: ${object.user_id.name} <${object.user_id.address_id.email}>\n"
+"\n"
+"            "
+msgstr "\nEn data ${date_now} s'ha obert el cas amb l'assumpte: ${object.name}\n\n- Identificador del cas: #${object.id}\n- Responsable: ${object.user_id.name} <${object.user_id.address_id.email}>\n\n            "
 
 #. module: crm_poweremail
 #: view:crm.case.rule:0
@@ -85,10 +199,25 @@ msgid "E-Mail Actions"
 msgstr "Accions de correu electrònic"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:161
+#: model:ir.actions.act_window,name:crm_poweremail.action_wizard_log_reply_attachment_form
+msgid "Send case with attachment"
+msgstr "Enviar cas amb fitxer adjunt"
+
+#. module: crm_poweremail
+#: view:crm.case:0
+msgid "Watch this case"
+msgstr "Observa aquest cas"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:464
 #, python-format
 msgid "No E-Mail ID Found for your Company address!"
 msgstr "No s'ha trobat la ID del correu electrònic de la direcció de la seva Companyia"
+
+#. module: crm_poweremail
+#: field:wizard.log.reply.attachment,info:0
+msgid "Info"
+msgstr "Informació"
 
 #. module: crm_poweremail
 #: constraint:ir.ui.view:0
@@ -96,35 +225,56 @@ msgid "Invalid XML for View Architecture!"
 msgstr "Arquitectura del XML invàlida!"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/poweremail_mailbox.py:41
-#, python-format
-msgid "Could not parse poweremail_mailbox pem_from address with qreu"
-msgstr "No es pot tractar l'adreça \"pem_from\" del correu de poweremail amb \"qreu\""
+#: view:crm.case:0
+msgid "Watchers"
+msgstr "Observadors"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:219
+#: code:addons/crm_poweremail/wizard/wizard_log_reply_with_attachment.py:81
+#, python-format
+msgid "User error"
+msgstr "Error d'usuari"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:564
 #, python-format
 msgid "Poweremail template \"Email TO\" has bad formatted address"
 msgstr "La direcció \"TO\" de la plantilla Power E-mail no té un format correcte"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:144
-#, python-format
-msgid ""
-"Can not send mail with empty body,you should have description in the body"
-msgstr "No es pot enviar un correu amb el cos buit, hauria d'haver una descripció en el cos del missatge"
+#: view:wizard.log.reply.attachment:0
+msgid "Attachment 3"
+msgstr "Adjunt 3"
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
-msgid ""
-"\n"
-"In date ${date_now} the case has been Opened with the subject: ${object.name}\n"
-"Case Identifier: #${object.id}\n"
-"\n"
-"Responsible: ${object.user_id.name} <${object.user_id.address_id.email}>\n"
-"\n"
-"            "
-msgstr "\nEn data ${date_now} s'ha obert un cas amb l'assumpte: ${object.name}\nIdentificador del cas: #${object.id}\n\nResponsable: ${object.user_id.name} <${object.user_id.address_id.email}>\n\n            "
+#: view:wizard.log.reply.attachment:0
+msgid "Attachment 2"
+msgstr "Adjunt 2"
+
+#. module: crm_poweremail
+#: view:wizard.log.reply.attachment:0
+msgid "Attachment 1"
+msgstr "Adjunt 1"
+
+#. module: crm_poweremail
+#: view:crm.case:0
+msgid "Send Partner & Historize"
+msgstr "Enviar al soci i historitzar"
+
+#. module: crm_poweremail
+#: view:wizard.log.reply.attachment:0
+msgid "Attachment 5"
+msgstr "Adjunt 5"
+
+#. module: crm_poweremail
+#: view:wizard.log.reply.attachment:0
+msgid "Attachment 4"
+msgstr "Adjunt 4"
+
+#. module: crm_poweremail
+#: model:ir.model,name:crm_poweremail.model_wizard_log_reply_attachment
+msgid "wizard.log.reply.attachment"
+msgstr "wizard.log.reply.attachment"
 
 #. module: crm_poweremail
 #: field:crm.case,conversation_id:0
@@ -132,15 +282,7 @@ msgid "Conversation"
 msgstr "Conversa"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:96
-#, python-format
-msgid ""
-"No E-Mail ID Found in Power Email for this section or missing reply address "
-"in section."
-msgstr "No s'ha trobat el ID del correu electrònic per aquesta secció o falta el correu electrònic de resposta per aquesta secció."
-
-#. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:89
+#: code:addons/crm_poweremail/crm.py:374
 #, python-format
 msgid ""
 "No E-Mail ID Found for your Company address or missing reply address in "
@@ -148,13 +290,28 @@ msgid ""
 msgstr "No s'ha trobat el ID del correu electrònic de la seva Companyia o falta el correu electrònic de resposta per aquesta secció!"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:163
+#: view:wizard.log.reply.attachment:0
+msgid "Do you want to send attachment?"
+msgstr "Voleu enviar un fitxer adjunt?"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:466 view:wizard.log.reply.attachment:0
 #, python-format
 msgid "Send"
 msgstr "Enviar"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:140
+#: field:wizard.log.reply.attachment,case_id:0
+msgid "CRM case"
+msgstr "Cas CRM"
+
+#. module: crm_poweremail
+#: view:crm.case:0
+msgid "Assign to me"
+msgstr "Assigna'm"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:442
 #, python-format
 msgid ""
 "You must define a responsible user for this case in order to use this "
@@ -167,16 +324,29 @@ msgid "History"
 msgstr "Historial"
 
 #. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:253
+#, python-format
+msgid "Your address does not have an email!"
+msgstr "La teva adreça no té correu electrònic!"
+
+#. module: crm_poweremail
 #: model:ir.module.module,shortdesc:crm_poweremail.module_meta_information
 msgid "CRM Poweremail"
 msgstr "CRM Poweremail"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:88 code:addons/crm_poweremail/crm.py:95
-#: code:addons/crm_poweremail/crm.py:136 code:addons/crm_poweremail/crm.py:139
-#: code:addons/crm_poweremail/crm.py:143 code:addons/crm_poweremail/crm.py:160
-#: code:addons/crm_poweremail/crm.py:219 code:addons/crm_poweremail/crm.py:227
-#: code:addons/crm_poweremail/crm.py:237
+#: code:addons/crm_poweremail/wizard/wizard_log_reply_with_attachment.py:82
+#, python-format
+msgid "You are trying to send {}MB. The limit is {}MB"
+msgstr "Esteu intentant enviar {} MB. El límit és de {} MB."
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:247 code:addons/crm_poweremail/crm.py:252
+#: code:addons/crm_poweremail/crm.py:373 code:addons/crm_poweremail/crm.py:380
+#: code:addons/crm_poweremail/crm.py:438 code:addons/crm_poweremail/crm.py:441
+#: code:addons/crm_poweremail/crm.py:445 code:addons/crm_poweremail/crm.py:463
+#: code:addons/crm_poweremail/crm.py:564 code:addons/crm_poweremail/crm.py:572
+#: code:addons/crm_poweremail/crm.py:582
 #, python-format
 msgid "Error!"
 msgstr "Error!"
@@ -203,16 +373,53 @@ msgid "PowerEmail Template"
 msgstr "Plantilla PowerEmail"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:137
-#, python-format
-msgid "You must put a Partner eMail to use this action!"
-msgstr "S'ha d'introduïr el correu electrònic de l'Empresa per poder utilitzar aquesta acció"
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close_automatically_pending
+msgid ""
+"\n"
+"<%\n"
+"    rule_obj = pool.get('crm.case.rule')\n"
+"    imd_obj = pool.get('ir.model.data')\n"
+"    rule_id = imd_obj.get_object_reference(cursor, uid, 'crm_poweremail', 'crm_poweremail_rule_auto_close_from_pending')[1]\n"
+"    days_passed = int(rule_obj.simple_browse(cursor, uid, rule_id).trg_date_range)\n"
+"%>\n"
+"\n"
+"Hello ${object.partner_id.name},\n"
+"\n"
+"We closed the case #${object.id} because more than ${days_passed} days have passed without activity.\n"
+"\n"
+"If the issue is already resolved, you don't need to do anything. If you still need help, please reply to this email.\n"
+"\n"
+"Best regards,\n"
+"The GISCE-TI team\n"
+"         "
+msgstr "\n<%\n    rule_obj = pool.get('crm.case.rule')\n    imd_obj = pool.get('ir.model.data')\n    rule_id = imd_obj.get_object_reference(cursor, uid, 'crm_poweremail', 'crm_poweremail_rule_auto_close_from_pending')[1]\n    days_passed = int(rule_obj.simple_browse(cursor, uid, rule_id).trg_date_range)\n%>\n\nHola ${object.partner_id.name},\n\nHem tancat el cas #${object.id} perquè han passat més de ${days_passed} dies sense activitat.\n\nSi el problema ja s'ha resolt, no cal que feu res. Si encara necessiteu ajuda, responeu a aquest correu electrònic.\n\nAtentament,\nL'equip de GISCE-TI\n         "
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:227
+#: field:wizard.log.reply.attachment,file_1:0
+#: field:wizard.log.reply.attachment,file_2:0
+#: field:wizard.log.reply.attachment,file_3:0
+#: field:wizard.log.reply.attachment,file_4:0
+#: field:wizard.log.reply.attachment,file_5:0
+msgid "File"
+msgstr "Fitxer"
+
+#. module: crm_poweremail
+#: model:ir.actions.act_window,name:crm_poweremail.action_sc_link_case_emails
+msgid "Conversation Emails"
+msgstr "Correus electrònics de conversa"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:572
 #, python-format
 msgid "Poweremail template \"Email CC\" has bad formatted address"
 msgstr "La direcció \"CC\" de la plantilla Power E-mail no té un format correcte"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/wizard/wizard_log_reply_with_attachment.py:30
+#: view:wizard.log.reply.attachment:0
+#, python-format
+msgid "Select a file to send as an attachment"
+msgstr "Seleccioneu un fitxer per enviar-lo com a adjunt"
 
 #. module: crm_poweremail
 #: model:ir.module.module,description:crm_poweremail.module_meta_information
@@ -225,3 +432,8 @@ msgid ""
 "          See: https://github.com/openlabs/poweremail/issues/24\n"
 "    "
 msgstr "\n    Aquest mòdul proveeix :\n        * Integració entre CRM i Poweremail\n        \n    NOTA: Es necessita poweremail amb suport per converses.\n          See: https://github.com/openlabs/poweremail/issues/24\n    "
+
+#. module: crm_poweremail
+#: field:wizard.log.reply.attachment,add_attachment:0
+msgid "Send with attachment?"
+msgstr "Enviar amb l'adjunt?"

--- a/i18n/crm_poweremail.pot
+++ b/i18n/crm_poweremail.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 5.0.14\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2018-02-20 08:47\n"
-"PO-Revision-Date: 2018-02-20 08:47\n"
+"POT-Creation-Date: 2026-06-22 16:43\n"
+"PO-Revision-Date: 2026-06-22 16:43\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -29,20 +29,20 @@ msgid "\n"
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:237
+#: code:addons/crm_poweremail/crm.py:582
 #, python-format
 msgid "Poweremail template \"Email BCC\" has bad formatted address"
 msgstr ""
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_new
-msgid "\n"
-"In date ${date_now} we have recieved the case with the subject: ${object.name}\n"
-"Case Identifier: #${object.id}\n"
-"\n"
-"Waiting for a responsible to take over the case.\n"
-"\n"
-"            "
+#: view:crm.case:0
+msgid "Case-Related Attachments"
+msgstr ""
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:381
+#, python-format
+msgid "Missing Poweremail-Account with Reply-To of the Case Section."
 msgstr ""
 
 #. module: crm_poweremail
@@ -51,7 +51,30 @@ msgid "Poweremail Template"
 msgstr ""
 
 #. module: crm_poweremail
+#: field:wizard.log.reply.attachment,filename_1:0
+#: field:wizard.log.reply.attachment,filename_2:0
+#: field:wizard.log.reply.attachment,filename_3:0
+#: field:wizard.log.reply.attachment,filename_4:0
+#: field:wizard.log.reply.attachment,filename_5:0
+msgid "Filename"
+msgstr ""
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_new
+msgid "\n"
+"In date ${date_now} we have recieved the case with the subject: ${object.name}\n"
+"\n"
+"- Case Identifier: #${object.id}\n"
+"\n"
+"Waiting for a responsible to take over the case.\n"
+"\n"
+"            "
+msgstr ""
+
+#. module: crm_poweremail
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close_automatically_open
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close_automatically_pending
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_new
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_open
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_pending
@@ -59,10 +82,44 @@ msgid "${object.name}"
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/poweremail_mailbox.py:165
-#: code:addons/crm_poweremail/poweremail_mailbox.py:174
+#: code:addons/crm_poweremail/wizard/wizard_log_reply_with_attachment.py:68
+#, python-format
+msgid "From CRM case [{}] {}"
+msgstr ""
+
+#. module: crm_poweremail
+#: constraint:ir.actions.act_window:0
+msgid "Invalid model name in the action definition."
+msgstr ""
+
+#. module: crm_poweremail
+#: view:crm.case:0
+#: field:crm.case,bcc_address_ids:0
+msgid "Secret Watchers Addresses (BCC)"
+msgstr ""
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/poweremail_mailbox.py:176
+#: code:addons/crm_poweremail/poweremail_mailbox.py:187
 #, python-format
 msgid "Reply"
+msgstr ""
+
+#. module: crm_poweremail
+#: field:crm.case,attachment_ids:0
+msgid "Adjuntos relacionados"
+msgstr ""
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:439
+#, python-format
+msgid "You must put a Partner eMail to use this action!"
+msgstr ""
+
+#. module: crm_poweremail
+#: view:crm.case:0
+#: field:crm.case,cc_address_ids:0
+msgid "Watchers Addresses (CC)"
 msgstr ""
 
 #. module: crm_poweremail
@@ -71,8 +128,62 @@ msgid "Conversations"
 msgstr ""
 
 #. module: crm_poweremail
+#: constraint:ir.model:0
+msgid "The Object name must start with x_ and not contain any special character !"
+msgstr ""
+
+#. module: crm_poweremail
 #: field:crm.case,conversation_mails:0
 msgid "unknown"
+msgstr ""
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close_automatically_open
+msgid "\n"
+"<%\n"
+"    rule_obj = pool.get('crm.case.rule')\n"
+"    imd_obj = pool.get('ir.model.data')\n"
+"    rule_id = imd_obj.get_object_reference(cursor, uid, 'crm_poweremail', 'crm_poweremail_rule_auto_close_from_open')[1]\n"
+"    days_passed = int(rule_obj.simple_browse(cursor, uid, rule_id).trg_date_range)\n"
+"%>\n"
+"\n"
+"Hello ${object.partner_id.name},\n"
+"\n"
+"We closed the case #${object.id} because more than ${days_passed} days have passed without activity.\n"
+"\n"
+"If the issue is already resolved, you don't need to do anything. If you still need help, please reply to this email.\n"
+"\n"
+"Best regards,\n"
+"The GISCE-TI team\n"
+"         "
+msgstr ""
+
+#. module: crm_poweremail
+#: field:crm.case,email_bcc:0
+msgid "Secret Watchers Emails"
+msgstr ""
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:446
+#, python-format
+msgid "Can not send mail with empty body,you should have description in the body"
+msgstr ""
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:248
+#, python-format
+msgid "You do not have an address!"
+msgstr ""
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
+msgid "\n"
+"In date ${date_now} the case has been Opened with the subject: ${object.name}\n"
+"\n"
+"- Case Identifier: #${object.id}\n"
+"- Responsible: ${object.user_id.name} <${object.user_id.address_id.email}>\n"
+"\n"
+"            "
 msgstr ""
 
 #. module: crm_poweremail
@@ -81,9 +192,24 @@ msgid "E-Mail Actions"
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:161
+#: model:ir.actions.act_window,name:crm_poweremail.action_wizard_log_reply_attachment_form
+msgid "Send case with attachment"
+msgstr ""
+
+#. module: crm_poweremail
+#: view:crm.case:0
+msgid "Watch this case"
+msgstr ""
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:464
 #, python-format
 msgid "No E-Mail ID Found for your Company address!"
+msgstr ""
+
+#. module: crm_poweremail
+#: field:wizard.log.reply.attachment,info:0
+msgid "Info"
 msgstr ""
 
 #. module: crm_poweremail
@@ -92,32 +218,55 @@ msgid "Invalid XML for View Architecture!"
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/poweremail_mailbox.py:41
-#, python-format
-msgid "Could not parse poweremail_mailbox pem_from address with qreu"
+#: view:crm.case:0
+msgid "Watchers"
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:219
+#: code:addons/crm_poweremail/wizard/wizard_log_reply_with_attachment.py:81
+#, python-format
+msgid "User error"
+msgstr ""
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:564
 #, python-format
 msgid "Poweremail template \"Email TO\" has bad formatted address"
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:144
-#, python-format
-msgid "Can not send mail with empty body,you should have description in the body"
+#: view:wizard.log.reply.attachment:0
+msgid "Attachment 3"
 msgstr ""
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
-msgid "\n"
-"In date ${date_now} the case has been Opened with the subject: ${object.name}\n"
-"Case Identifier: #${object.id}\n"
-"\n"
-"Responsible: ${object.user_id.name} <${object.user_id.address_id.email}>\n"
-"\n"
-"            "
+#: view:wizard.log.reply.attachment:0
+msgid "Attachment 2"
+msgstr ""
+
+#. module: crm_poweremail
+#: view:wizard.log.reply.attachment:0
+msgid "Attachment 1"
+msgstr ""
+
+#. module: crm_poweremail
+#: view:crm.case:0
+msgid "Send Partner & Historize"
+msgstr ""
+
+#. module: crm_poweremail
+#: view:wizard.log.reply.attachment:0
+msgid "Attachment 5"
+msgstr ""
+
+#. module: crm_poweremail
+#: view:wizard.log.reply.attachment:0
+msgid "Attachment 4"
+msgstr ""
+
+#. module: crm_poweremail
+#: model:ir.model,name:crm_poweremail.model_wizard_log_reply_attachment
+msgid "wizard.log.reply.attachment"
 msgstr ""
 
 #. module: crm_poweremail
@@ -126,25 +275,35 @@ msgid "Conversation"
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:96
-#, python-format
-msgid "No E-Mail ID Found in Power Email for this section or missing reply address in section."
-msgstr ""
-
-#. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:89
+#: code:addons/crm_poweremail/crm.py:374
 #, python-format
 msgid "No E-Mail ID Found for your Company address or missing reply address in section!"
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:163
+#: view:wizard.log.reply.attachment:0
+msgid "Do you want to send attachment?"
+msgstr ""
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:466
+#: view:wizard.log.reply.attachment:0
 #, python-format
 msgid "Send"
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:140
+#: field:wizard.log.reply.attachment,case_id:0
+msgid "CRM case"
+msgstr ""
+
+#. module: crm_poweremail
+#: view:crm.case:0
+msgid "Assign to me"
+msgstr ""
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:442
 #, python-format
 msgid "You must define a responsible user for this case in order to use this action!"
 msgstr ""
@@ -155,20 +314,34 @@ msgid "History"
 msgstr ""
 
 #. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:253
+#, python-format
+msgid "Your address does not have an email!"
+msgstr ""
+
+#. module: crm_poweremail
 #: model:ir.module.module,shortdesc:crm_poweremail.module_meta_information
 msgid "CRM Poweremail"
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:88
-#: code:addons/crm_poweremail/crm.py:95
-#: code:addons/crm_poweremail/crm.py:136
-#: code:addons/crm_poweremail/crm.py:139
-#: code:addons/crm_poweremail/crm.py:143
-#: code:addons/crm_poweremail/crm.py:160
-#: code:addons/crm_poweremail/crm.py:219
-#: code:addons/crm_poweremail/crm.py:227
-#: code:addons/crm_poweremail/crm.py:237
+#: code:addons/crm_poweremail/wizard/wizard_log_reply_with_attachment.py:82
+#, python-format
+msgid "You are trying to send {}MB. The limit is {}MB"
+msgstr ""
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:247
+#: code:addons/crm_poweremail/crm.py:252
+#: code:addons/crm_poweremail/crm.py:373
+#: code:addons/crm_poweremail/crm.py:380
+#: code:addons/crm_poweremail/crm.py:438
+#: code:addons/crm_poweremail/crm.py:441
+#: code:addons/crm_poweremail/crm.py:445
+#: code:addons/crm_poweremail/crm.py:463
+#: code:addons/crm_poweremail/crm.py:564
+#: code:addons/crm_poweremail/crm.py:572
+#: code:addons/crm_poweremail/crm.py:582
 #, python-format
 msgid "Error!"
 msgstr ""
@@ -194,15 +367,51 @@ msgid "PowerEmail Template"
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:137
-#, python-format
-msgid "You must put a Partner eMail to use this action!"
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close_automatically_pending
+msgid "\n"
+"<%\n"
+"    rule_obj = pool.get('crm.case.rule')\n"
+"    imd_obj = pool.get('ir.model.data')\n"
+"    rule_id = imd_obj.get_object_reference(cursor, uid, 'crm_poweremail', 'crm_poweremail_rule_auto_close_from_pending')[1]\n"
+"    days_passed = int(rule_obj.simple_browse(cursor, uid, rule_id).trg_date_range)\n"
+"%>\n"
+"\n"
+"Hello ${object.partner_id.name},\n"
+"\n"
+"We closed the case #${object.id} because more than ${days_passed} days have passed without activity.\n"
+"\n"
+"If the issue is already resolved, you don't need to do anything. If you still need help, please reply to this email.\n"
+"\n"
+"Best regards,\n"
+"The GISCE-TI team\n"
+"         "
 msgstr ""
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:227
+#: field:wizard.log.reply.attachment,file_1:0
+#: field:wizard.log.reply.attachment,file_2:0
+#: field:wizard.log.reply.attachment,file_3:0
+#: field:wizard.log.reply.attachment,file_4:0
+#: field:wizard.log.reply.attachment,file_5:0
+msgid "File"
+msgstr ""
+
+#. module: crm_poweremail
+#: model:ir.actions.act_window,name:crm_poweremail.action_sc_link_case_emails
+msgid "Conversation Emails"
+msgstr ""
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:572
 #, python-format
 msgid "Poweremail template \"Email CC\" has bad formatted address"
+msgstr ""
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/wizard/wizard_log_reply_with_attachment.py:30
+#: view:wizard.log.reply.attachment:0
+#, python-format
+msgid "Select a file to send as an attachment"
 msgstr ""
 
 #. module: crm_poweremail
@@ -214,5 +423,10 @@ msgid "\n"
 "    NOTE: Needs poweremail with conversations suport.\n"
 "          See: https://github.com/openlabs/poweremail/issues/24\n"
 "    "
+msgstr ""
+
+#. module: crm_poweremail
+#: field:wizard.log.reply.attachment,add_attachment:0
+msgid "Send with attachment?"
 msgstr ""
 

--- a/i18n/es_ES.po
+++ b/i18n/es_ES.po
@@ -2,14 +2,15 @@
 # This file contains the translation of the following modules:
 # 
 # Translators:
+#   <>, 2026.
 # Jaume  Florez Valenzuela <jflorez@gisce.net>, 2017, 2018.
 msgid ""
 msgstr ""
 "Project-Id-Version: GISCE-ERP\n"
 "Report-Msgid-Bugs-To: https://github.com/gisce/erp/issues\n"
-"POT-Creation-Date: 2018-02-20 08:47\n"
-"PO-Revision-Date: 2018-02-21 14:56+0000\n"
-"Last-Translator: Jaume  Florez Valenzuela <jflorez@gisce.net>\n"
+"POT-Creation-Date: 2026-06-22 16:43\n"
+"PO-Revision-Date: 2026-06-22 14:58+0000\n"
+"Last-Translator: destanyol <>\n"
 "Language-Team: Spanish (Spain) <erp@dev.gisce.net>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -32,22 +33,21 @@ msgid ""
 msgstr "\nEl caso con el identificador: #${object.id}; con el asunto: \"${object.name}\" se ha CERRADO.\n\n             "
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:237
+#: code:addons/crm_poweremail/crm.py:582
 #, python-format
 msgid "Poweremail template \"Email BCC\" has bad formatted address"
 msgstr "La dirección \"BCC\" de la plantilla Power E-mail no tiene un formato correcto"
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_new
-msgid ""
-"\n"
-"In date ${date_now} we have recieved the case with the subject: ${object.name}\n"
-"Case Identifier: #${object.id}\n"
-"\n"
-"Waiting for a responsible to take over the case.\n"
-"\n"
-"            "
-msgstr "\nEn fecha ${date_now} hemos recibido un caso con el asunto: ${object.name}\n\nIdentificador del Caso: #${object.id}\n\nEsperando la asignación de un responsable.\n\n             "
+#: view:crm.case:0
+msgid "Case-Related Attachments"
+msgstr "Documentos adjuntos relacionados con el caso"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:381
+#, python-format
+msgid "Missing Poweremail-Account with Reply-To of the Case Section."
+msgstr "Falta la Cuenta de Poweremail con Responder A en la sección del caso."
 
 #. module: crm_poweremail
 #: field:crm.case.rule,pm_template_id:0
@@ -55,7 +55,31 @@ msgid "Poweremail Template"
 msgstr "Plantilla Poweremail"
 
 #. module: crm_poweremail
+#: field:wizard.log.reply.attachment,filename_1:0
+#: field:wizard.log.reply.attachment,filename_2:0
+#: field:wizard.log.reply.attachment,filename_3:0
+#: field:wizard.log.reply.attachment,filename_4:0
+#: field:wizard.log.reply.attachment,filename_5:0
+msgid "Filename"
+msgstr "Nombre del archivo"
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_new
+msgid ""
+"\n"
+"In date ${date_now} we have recieved the case with the subject: ${object.name}\n"
+"\n"
+"- Case Identifier: #${object.id}\n"
+"\n"
+"Waiting for a responsible to take over the case.\n"
+"\n"
+"            "
+msgstr "\nEn la fecha ${date_now} recibimos el caso con el asunto: ${object.name}\n\n\n- Identificador del caso: #${object.id}\n\nEsperando a que un responsable se haga cargo del caso.\n\n            "
+
+#. module: crm_poweremail
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close_automatically_open
+#: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_close_automatically_pending
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_new
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_open
 #: model:poweremail.templates,def_subject:crm_poweremail.crm_poweremail_case_template_pending
@@ -63,11 +87,43 @@ msgid "${object.name}"
 msgstr "${object.name}"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/poweremail_mailbox.py:165
-#: code:addons/crm_poweremail/poweremail_mailbox.py:174
+#: code:addons/crm_poweremail/wizard/wizard_log_reply_with_attachment.py:68
+#, python-format
+msgid "From CRM case [{}] {}"
+msgstr "Desde el caso CRM [{}] {}"
+
+#. module: crm_poweremail
+#: constraint:ir.actions.act_window:0
+msgid "Invalid model name in the action definition."
+msgstr "Nombre de modelo no válido en la definición de la acción."
+
+#. module: crm_poweremail
+#: view:crm.case:0 field:crm.case,bcc_address_ids:0
+msgid "Secret Watchers Addresses (BCC)"
+msgstr "Direcciones de Observadores Secretos (CCO)"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/poweremail_mailbox.py:176
+#: code:addons/crm_poweremail/poweremail_mailbox.py:187
 #, python-format
 msgid "Reply"
 msgstr "Resposta"
+
+#. module: crm_poweremail
+#: field:crm.case,attachment_ids:0
+msgid "Adjuntos relacionados"
+msgstr "Adjuntos relacionados"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:439
+#, python-format
+msgid "You must put a Partner eMail to use this action!"
+msgstr "Se debe facilitar la dirección de correo electrónico de la Empresa para utilitzar esta acción!"
+
+#. module: crm_poweremail
+#: view:crm.case:0 field:crm.case,cc_address_ids:0
+msgid "Watchers Addresses (CC)"
+msgstr "Direcciones de los observadores (CC)"
 
 #. module: crm_poweremail
 #: view:crm.case:0
@@ -75,9 +131,67 @@ msgid "Conversations"
 msgstr "Conversaciones"
 
 #. module: crm_poweremail
+#: constraint:ir.model:0
+msgid ""
+"The Object name must start with x_ and not contain any special character !"
+msgstr "El nombre del objeto debe comenzar con x_ y no contener ningún carácter especial!"
+
+#. module: crm_poweremail
 #: field:crm.case,conversation_mails:0
 msgid "unknown"
 msgstr "desconocido"
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close_automatically_open
+msgid ""
+"\n"
+"<%\n"
+"    rule_obj = pool.get('crm.case.rule')\n"
+"    imd_obj = pool.get('ir.model.data')\n"
+"    rule_id = imd_obj.get_object_reference(cursor, uid, 'crm_poweremail', 'crm_poweremail_rule_auto_close_from_open')[1]\n"
+"    days_passed = int(rule_obj.simple_browse(cursor, uid, rule_id).trg_date_range)\n"
+"%>\n"
+"\n"
+"Hello ${object.partner_id.name},\n"
+"\n"
+"We closed the case #${object.id} because more than ${days_passed} days have passed without activity.\n"
+"\n"
+"If the issue is already resolved, you don't need to do anything. If you still need help, please reply to this email.\n"
+"\n"
+"Best regards,\n"
+"The GISCE-TI team\n"
+"         "
+msgstr "\n<%\n    rule_obj = pool.get('crm.case.rule')\n    imd_obj = pool.get('ir.model.data')\n    rule_id = imd_obj.get_object_reference(cursor, uid, 'crm_poweremail', 'crm_poweremail_rule_auto_close_from_open')[1]\n    days_passed = int(rule_obj.simple_browse(cursor, uid, rule_id).trg_date_range)\n%>\n\nHola ${object.partner_id.name},\n\nCerramos el caso #${object.id} porque han transcurrido más de ${days_passed} días sin actividad.\n\nSi el problema ya está resuelto, no necesita hacer nada. Si aún necesita ayuda, responda a este correo electrónico.\n\nSaludos cordiales,\nEl equipo de GISCE-TI\n         "
+
+#. module: crm_poweremail
+#: field:crm.case,email_bcc:0
+msgid "Secret Watchers Emails"
+msgstr "Correos electrónicos de observadores secretos"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:446
+#, python-format
+msgid ""
+"Can not send mail with empty body,you should have description in the body"
+msgstr "No se puede enviar un correo sin cuerpo, debería haber una descripción en el cuerpo"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:248
+#, python-format
+msgid "You do not have an address!"
+msgstr "¡No tienes una dirección!"
+
+#. module: crm_poweremail
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
+msgid ""
+"\n"
+"In date ${date_now} the case has been Opened with the subject: ${object.name}\n"
+"\n"
+"- Case Identifier: #${object.id}\n"
+"- Responsible: ${object.user_id.name} <${object.user_id.address_id.email}>\n"
+"\n"
+"            "
+msgstr "\nEn la fecha ${date_now} se abrió el caso con el asunto: ${object.name}\n\n- Identificador del caso: #${object.id}\n- Responsable: ${object.user_id.name} <${object.user_id.address_id.email}>\n\n            "
 
 #. module: crm_poweremail
 #: view:crm.case.rule:0
@@ -85,10 +199,25 @@ msgid "E-Mail Actions"
 msgstr "Acciones de Correo Electrónico"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:161
+#: model:ir.actions.act_window,name:crm_poweremail.action_wizard_log_reply_attachment_form
+msgid "Send case with attachment"
+msgstr "Enviar caso con archivo adjunto"
+
+#. module: crm_poweremail
+#: view:crm.case:0
+msgid "Watch this case"
+msgstr "Observa este caso"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:464
 #, python-format
 msgid "No E-Mail ID Found for your Company address!"
 msgstr "No se ha encontrado un ID de correo electrónico para la dirección de su Compañía!"
+
+#. module: crm_poweremail
+#: field:wizard.log.reply.attachment,info:0
+msgid "Info"
+msgstr "Información"
 
 #. module: crm_poweremail
 #: constraint:ir.ui.view:0
@@ -96,35 +225,56 @@ msgid "Invalid XML for View Architecture!"
 msgstr "Arquitectura de XML inválida"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/poweremail_mailbox.py:41
-#, python-format
-msgid "Could not parse poweremail_mailbox pem_from address with qreu"
-msgstr "No se puede tratar la dirección \"pem from\" del mensaje de poweremail con \"qreu\""
+#: view:crm.case:0
+msgid "Watchers"
+msgstr "Observadores"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:219
+#: code:addons/crm_poweremail/wizard/wizard_log_reply_with_attachment.py:81
+#, python-format
+msgid "User error"
+msgstr "Error del usuario"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:564
 #, python-format
 msgid "Poweremail template \"Email TO\" has bad formatted address"
 msgstr "La dirección \"TO\" de la plantilla Power E-mail no tiene un formato correcto"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:144
-#, python-format
-msgid ""
-"Can not send mail with empty body,you should have description in the body"
-msgstr "No se puede enviar un correo sin cuerpo, debería haber una descripción en el cuerpo"
+#: view:wizard.log.reply.attachment:0
+msgid "Attachment 3"
+msgstr "Adjunto 3"
 
 #. module: crm_poweremail
-#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_open
-msgid ""
-"\n"
-"In date ${date_now} the case has been Opened with the subject: ${object.name}\n"
-"Case Identifier: #${object.id}\n"
-"\n"
-"Responsible: ${object.user_id.name} <${object.user_id.address_id.email}>\n"
-"\n"
-"            "
-msgstr "\nEn fecha ${date_now} el caso se ha Abierto con el asunto: ${object.name}\n\nIdentificador del Caso: #${object.id}\n\nResponsable: ${object.user_id.name} <${object.user_id.address_id.email}>\n\n       "
+#: view:wizard.log.reply.attachment:0
+msgid "Attachment 2"
+msgstr "Adjunto 2"
+
+#. module: crm_poweremail
+#: view:wizard.log.reply.attachment:0
+msgid "Attachment 1"
+msgstr "Adjunto 1"
+
+#. module: crm_poweremail
+#: view:crm.case:0
+msgid "Send Partner & Historize"
+msgstr "Enviar al socio e historizar"
+
+#. module: crm_poweremail
+#: view:wizard.log.reply.attachment:0
+msgid "Attachment 5"
+msgstr "Adjunto 5"
+
+#. module: crm_poweremail
+#: view:wizard.log.reply.attachment:0
+msgid "Attachment 4"
+msgstr "Adjunto 4"
+
+#. module: crm_poweremail
+#: model:ir.model,name:crm_poweremail.model_wizard_log_reply_attachment
+msgid "wizard.log.reply.attachment"
+msgstr "wizard.log.reply.attachment"
 
 #. module: crm_poweremail
 #: field:crm.case,conversation_id:0
@@ -132,15 +282,7 @@ msgid "Conversation"
 msgstr "Conversación"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:96
-#, python-format
-msgid ""
-"No E-Mail ID Found in Power Email for this section or missing reply address "
-"in section."
-msgstr "No se ha encontrdo el ID de correo electrónico en PowerEmail para esta sección o en la dirección de respuesta de esta sección."
-
-#. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:89
+#: code:addons/crm_poweremail/crm.py:374
 #, python-format
 msgid ""
 "No E-Mail ID Found for your Company address or missing reply address in "
@@ -148,13 +290,28 @@ msgid ""
 msgstr "No se ha encontrado el ID de correo electrónico para la dirección de su Compañía o en la dirección de resupesta de esta sección!"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:163
+#: view:wizard.log.reply.attachment:0
+msgid "Do you want to send attachment?"
+msgstr "¿Desea enviar un archivo adjunto?"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:466 view:wizard.log.reply.attachment:0
 #, python-format
 msgid "Send"
 msgstr "Enviar"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:140
+#: field:wizard.log.reply.attachment,case_id:0
+msgid "CRM case"
+msgstr "Caso de CRM"
+
+#. module: crm_poweremail
+#: view:crm.case:0
+msgid "Assign to me"
+msgstr "Asignarme"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:442
 #, python-format
 msgid ""
 "You must define a responsible user for this case in order to use this "
@@ -167,16 +324,29 @@ msgid "History"
 msgstr "Historial"
 
 #. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:253
+#, python-format
+msgid "Your address does not have an email!"
+msgstr "¡Tu dirección no tiene correo electrónico!"
+
+#. module: crm_poweremail
 #: model:ir.module.module,shortdesc:crm_poweremail.module_meta_information
 msgid "CRM Poweremail"
 msgstr "CRM Poweremail"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:88 code:addons/crm_poweremail/crm.py:95
-#: code:addons/crm_poweremail/crm.py:136 code:addons/crm_poweremail/crm.py:139
-#: code:addons/crm_poweremail/crm.py:143 code:addons/crm_poweremail/crm.py:160
-#: code:addons/crm_poweremail/crm.py:219 code:addons/crm_poweremail/crm.py:227
-#: code:addons/crm_poweremail/crm.py:237
+#: code:addons/crm_poweremail/wizard/wizard_log_reply_with_attachment.py:82
+#, python-format
+msgid "You are trying to send {}MB. The limit is {}MB"
+msgstr "Estás intentando enviar {}MB. El límite es {}MB."
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:247 code:addons/crm_poweremail/crm.py:252
+#: code:addons/crm_poweremail/crm.py:373 code:addons/crm_poweremail/crm.py:380
+#: code:addons/crm_poweremail/crm.py:438 code:addons/crm_poweremail/crm.py:441
+#: code:addons/crm_poweremail/crm.py:445 code:addons/crm_poweremail/crm.py:463
+#: code:addons/crm_poweremail/crm.py:564 code:addons/crm_poweremail/crm.py:572
+#: code:addons/crm_poweremail/crm.py:582
 #, python-format
 msgid "Error!"
 msgstr "Error!"
@@ -203,16 +373,53 @@ msgid "PowerEmail Template"
 msgstr "Plantilla PowerEmail"
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:137
-#, python-format
-msgid "You must put a Partner eMail to use this action!"
-msgstr "Se debe facilitar la dirección de correo electrónico de la Empresa para utilitzar esta acción!"
+#: model:poweremail.templates,def_body_text:crm_poweremail.crm_poweremail_case_template_close_automatically_pending
+msgid ""
+"\n"
+"<%\n"
+"    rule_obj = pool.get('crm.case.rule')\n"
+"    imd_obj = pool.get('ir.model.data')\n"
+"    rule_id = imd_obj.get_object_reference(cursor, uid, 'crm_poweremail', 'crm_poweremail_rule_auto_close_from_pending')[1]\n"
+"    days_passed = int(rule_obj.simple_browse(cursor, uid, rule_id).trg_date_range)\n"
+"%>\n"
+"\n"
+"Hello ${object.partner_id.name},\n"
+"\n"
+"We closed the case #${object.id} because more than ${days_passed} days have passed without activity.\n"
+"\n"
+"If the issue is already resolved, you don't need to do anything. If you still need help, please reply to this email.\n"
+"\n"
+"Best regards,\n"
+"The GISCE-TI team\n"
+"         "
+msgstr "\n<%\n    rule_obj = pool.get('crm.case.rule')\n    imd_obj = pool.get('ir.model.data')\n    rule_id = imd_obj.get_object_reference(cursor, uid, 'crm_poweremail', 'crm_poweremail_rule_auto_close_from_pending')[1]\n    days_passed = int(rule_obj.simple_browse(cursor, uid, rule_id).trg_date_range)\n%>\n\nHola ${object.partner_id.name},\n\nCerramos el caso #${object.id} porque han pasado más de ${days_passed} días sin actividad.\n\nSi el problema ya está resuelto, no necesita hacer nada. Si aún necesita ayuda, responda a este correo electrónico.\n\nSaludos cordiales,\nEl equipo de GISCE-TI\n         "
 
 #. module: crm_poweremail
-#: code:addons/crm_poweremail/crm.py:227
+#: field:wizard.log.reply.attachment,file_1:0
+#: field:wizard.log.reply.attachment,file_2:0
+#: field:wizard.log.reply.attachment,file_3:0
+#: field:wizard.log.reply.attachment,file_4:0
+#: field:wizard.log.reply.attachment,file_5:0
+msgid "File"
+msgstr "Archivo"
+
+#. module: crm_poweremail
+#: model:ir.actions.act_window,name:crm_poweremail.action_sc_link_case_emails
+msgid "Conversation Emails"
+msgstr "Correos electrónicos de conversación"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/crm.py:572
 #, python-format
 msgid "Poweremail template \"Email CC\" has bad formatted address"
 msgstr "La dirección \"CC\" de la plantilla Power E-mail no tiene un formato correcto"
+
+#. module: crm_poweremail
+#: code:addons/crm_poweremail/wizard/wizard_log_reply_with_attachment.py:30
+#: view:wizard.log.reply.attachment:0
+#, python-format
+msgid "Select a file to send as an attachment"
+msgstr "Seleccione un archivo para enviar como archivo adjunto."
 
 #. module: crm_poweremail
 #: model:ir.module.module,description:crm_poweremail.module_meta_information
@@ -225,3 +432,8 @@ msgid ""
 "          See: https://github.com/openlabs/poweremail/issues/24\n"
 "    "
 msgstr "\n    Este módulo provee:\n        * Integración entre CRM y Poweremail\n        \n    NOTA: Se necesita poweremail con soporte para conversaciones.\n          Ver: https://github.com/openlabs/poweremail/issues/24\n    "
+
+#. module: crm_poweremail
+#: field:wizard.log.reply.attachment,add_attachment:0
+msgid "Send with attachment?"
+msgstr "¿Enviar con archivo adjunto?"

--- a/migrations/5.0.26.5.0/post-0002_new_close_automatically_case_template.py
+++ b/migrations/5.0.26.5.0/post-0002_new_close_automatically_case_template.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from oopgrade.oopgrade import MigrationHelper
+from tools import config
+
+
+def up(cursor, installed_version):
+    if not installed_version or config.updating_all:
+        return
+
+    module = 'crm_poweremail'
+    mh = MigrationHelper(cursor, module)
+
+    file = 'crm_data.xml'
+    views = [
+        'crm_poweremail_case_template_close_automatically_pending',
+        'crm_poweremail_case_template_close_automatically_open',
+        'crm_poweremail_rule_auto_close_from_pending',
+        'crm_poweremail_rule_auto_close_from_open',
+    ]
+    mh.update_xml_records(xml_path=file, init_record_ids=views)
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/migrations/5.0.26.5.0/post-0002_new_close_automatically_case_template.py
+++ b/migrations/5.0.26.5.0/post-0002_new_close_automatically_case_template.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 from oopgrade.oopgrade import MigrationHelper
 from tools import config
+from tools.translate import trans_load
 
 
 def up(cursor, installed_version):
@@ -19,6 +20,8 @@ def up(cursor, installed_version):
         'crm_poweremail_rule_auto_close_from_open',
     ]
     mh.update_xml_records(xml_path=file, init_record_ids=views)
+    trans_load(cursor, '{}/{}/i18n/ca_ES.po'.format(config['addons_path'], module), 'ca_ES')
+    trans_load(cursor, '{}/{}/i18n/es_ES.po'.format(config['addons_path'], module), 'es_ES')
 
 
 def down(cursor, installed_version):


### PR DESCRIPTION
## Comportamiento nuevo

Enviar un correo automáticamente con la notificación de cierre automático de los casos después de 15 días de inactividad.

## Comportamiento antiguo

No notificaba el cierre por inactividad

## Relacionat

- Tasca: TASK-85341
- Trello:
- Cas:
- Depèn de:
  - https://github.com/gisce/crm_poweremail/pull/81
  - https://github.com/gisce/erp/pull/28059

### Afectacions / Migració de dades

- [x] **Reiniciar serveis:**
    - webclient
- [x] **Actualizació mòduls:**
    - 5.0.26.5.0
    - crm_poweremail   -   post-0002_new_close_automatically_case_template.py
- [ ] **Migració de dades**


