### PR TITLE
Normalize markdown image descriptions

### DIFF
--- a/crm.py
+++ b/crm.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 from datetime import datetime
 from email.utils import make_msgid
+import re
 from mako.template import Template
 
 from markdown import markdown
@@ -325,11 +326,21 @@ class CrmCase(osv.osv):
         return list(set(emails+watchers_bcc+context.get('email_bcc', [])))
 
     def parse_body_markdown(self, html):
+        def clean_image_description(match):
+            description = ' '.join(match.group(1).split())
+            return '![{}]({})'.format(description, match.group(2))
+
         if (
                 html.strip()[0] != '<' and
                 "<br/>" not in html and
                 "<br>" not in html
         ):
+            html = re.sub(
+                r'!\[([^\]]*)\]\(([^)]*)\)',
+                clean_image_description,
+                html,
+                flags=re.DOTALL
+            )
             html = markdown(html)
         return html
 

--- a/crm.py
+++ b/crm.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import
 from datetime import datetime
 from email.utils import make_msgid
-import re
 from mako.template import Template
 
 from markdown import markdown
@@ -11,6 +10,8 @@ from tools.translate import _
 from tools import config
 from qreu import address as qaddress
 from qreu.address import getaddresses
+
+from .markdown_utils import normalize_markdown_image_descriptions
 
 
 class CrmCase(osv.osv):
@@ -326,21 +327,12 @@ class CrmCase(osv.osv):
         return list(set(emails+watchers_bcc+context.get('email_bcc', [])))
 
     def parse_body_markdown(self, html):
-        def clean_image_description(match):
-            description = ' '.join(match.group(1).split())
-            return u'![{}]({})'.format(description, match.group(2))
-
         if (
                 html.strip()[0] != '<' and
                 "<br/>" not in html and
                 "<br>" not in html
         ):
-            html = re.sub(
-                r'!\[([^\]]*)\]\(([^)]*)\)',
-                clean_image_description,
-                html,
-                flags=re.DOTALL
-            )
+            html = normalize_markdown_image_descriptions(html)
             html = markdown(html)
         return html
 

--- a/crm.py
+++ b/crm.py
@@ -328,7 +328,7 @@ class CrmCase(osv.osv):
     def parse_body_markdown(self, html):
         def clean_image_description(match):
             description = ' '.join(match.group(1).split())
-            return '![{}]({})'.format(description, match.group(2))
+            return u'![{}]({})'.format(description, match.group(2))
 
         if (
                 html.strip()[0] != '<' and

--- a/markdown_utils.py
+++ b/markdown_utils.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+import re
+
+try:
+    text_type = unicode
+except NameError:
+    text_type = str
+
+
+def normalize_markdown_image_descriptions(markdown_body):
+    """Collapse whitespace only inside Markdown image descriptions."""
+    if not markdown_body:
+        return markdown_body
+
+    def clean_image_description(match):
+        description = ' '.join(match.group(1).split())
+        template = (
+            u'![{}]({})'
+            if isinstance(match.group(0), text_type)
+            else '![{}]({})'
+        )
+        return template.format(description, match.group(2))
+
+    return re.sub(
+        r'!\[([^\]]*)\]\(([^)]*)\)',
+        clean_image_description,
+        markdown_body,
+        flags=re.DOTALL
+    )

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -9,6 +9,9 @@ from html2text import html2text
 from lxml import html as lxml_html
 import email as email_parser
 import re
+
+from .markdown_utils import normalize_markdown_image_descriptions
+
 try:
     from urllib.parse import unquote
 except ImportError:
@@ -305,7 +308,10 @@ class PoweremailMailboxCRM(osv.osv):
             html_body = _replace_inline_image_sources(
                 html_body, attachment_map
             )
-            return _escape_mdx_email_autolinks(html2text(html_body).strip())
+            markdown_body = normalize_markdown_image_descriptions(
+                html2text(html_body).strip()
+            )
+            return _escape_mdx_email_autolinks(markdown_body)
         return p_mail.pem_body_text or mail.body_parts.get('plain') or ''
 
     def _markdown_inline_images_enabled(self, cursor, uid):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -428,6 +428,33 @@ class TestCRMPoweremail(testing.OOTestCase):
             )
             self.assertFalse(re.search(r'cid:logo%40example.com', body_text))
 
+    def test_markdown_image_descriptions_strip_newlines(self):
+        """Test image markdown descriptions are kept on a single line."""
+        self.logger.info('Testing markdown image descriptions')
+        case_obj = self.pool.get('crm.case')
+        markdown_text = (
+            'Gracias\n\n'
+            '![Logotipo, nombre de la empresa\n\n'
+            'Descripción generada automáticamente](attachment://297676)_\n\n'
+            '_\n\n'
+            '![Icono\n\n'
+            'Descripción generada automáticamente](attachment://297678)__**_'
+            'Departamento de\nIngeniería'
+        )
+        html = case_obj.parse_body_markdown(markdown_text)
+
+        self.assertIn(
+            'Logotipo, nombre de la empresa Descripción generada '
+            'automáticamente',
+            html
+        )
+        self.assertIn(
+            'Icono Descripción generada automáticamente',
+            html
+        )
+        self.assertNotIn('Logotipo, nombre de la empresa\n', html)
+        self.assertNotIn('Icono\n', html)
+
     def test_incoming_html_inline_images_keep_text_by_default(self):
         """Test HTML conversion is disabled by default for CRM mail."""
         self.logger.info('Testing incoming inline images opt-in config')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -383,7 +383,8 @@ class TestCRMPoweremail(testing.OOTestCase):
             'Content-Type: text/html; charset="utf-8"\r\n'
             '\r\n'
             '<html><body><p>Hello <strong>CRM</strong></p>'
-            '<p><img alt="Logo" src="cid:logo%40example.com"></p>'
+            '<p><img alt="Logo\n\nDescripción generada automáticamente" '
+            'src="cid:logo%40example.com"></p>'
             '</body></html>\r\n'
             '--BOUNDARY\r\n'
             'Content-Type: image/png; name="logo.png"\r\n'
@@ -405,7 +406,9 @@ class TestCRMPoweremail(testing.OOTestCase):
                 'pem_body_text': 'fallback text',
                 'pem_body_html': (
                     '<html><body><p>Hello <strong>CRM</strong></p>'
-                    '<p><img alt="Logo" src="cid:logo%40example.com"></p>'
+                    '<p><img alt="Logo\n\n'
+                    'Descripción generada automáticamente" '
+                    'src="cid:logo%40example.com"></p>'
                     '</body></html>'
                 ),
                 'pem_account_id': account_id,
@@ -423,9 +426,11 @@ class TestCRMPoweremail(testing.OOTestCase):
 
             self.assertIn('Hello **CRM**', body_text)
             self.assertIn(
-                '![Logo](attachment://{0})'.format(attachment_id),
+                '![Logo Descripción generada automáticamente]'
+                '(attachment://{0})'.format(attachment_id),
                 body_text
             )
+            self.assertNotIn('Logo\n\nDescripción', body_text)
             self.assertFalse(re.search(r'cid:logo%40example.com', body_text))
 
     def test_markdown_image_descriptions_strip_newlines(self):


### PR DESCRIPTION
# :warning: EN CAS D'ERROR

## Causa de l'error

Alguns parsers generen descripcions d'imatge amb salts de línia dins l'alt text Markdown (`![...](attachment://...)`). El parser Markdown interpreta aquests salts com separadors de paràgraf i el render queda trencat.

També pot passar quan un correu HTML entrant porta salts de línia dins l'atribut `alt` d'una imatge: la conversió HTML → Markdown amb `html2text` conserva aquests salts dins la descripció.

## Como reproduir el error

Enviar o generar un cos Markdown amb una imatge tipus:

```md
![Logotipo, nombre de la empresa

Descripción generada automáticamente](attachment://297676)
```

O bé rebre un correu HTML de secció CRM amb una imatge inline que tingui l'`alt` trencat en diverses línies.

## Solució

S'ha afegit una normalització compartida que col·lapsa els salts de línia i espais interns només dins l'alt text de les imatges Markdown.

S'aplica en dues rutes:

- abans de convertir Markdown a HTML en `crm.case.parse_body_markdown`, per no trencar el render de sortida;
- després de convertir HTML entrant a Markdown en `poweremail.mailbox._email_body_as_markdown`, un cop ja han passat el match de secció CRM i el guard de `reply_to`.

El cos HTML existent i la resta del text Markdown no es modifiquen.

## Tests

- `/home/openclaw/.pyenv/versions/erp2/bin/python -m py_compile crm.py poweremail_mailbox.py markdown_utils.py tests/__init__.py tests/test_crm_case_rule.py`
- `/home/openclaw/.pyenv/versions/erp3/bin/python -m py_compile crm.py poweremail_mailbox.py markdown_utils.py tests/__init__.py tests/test_crm_case_rule.py`
- `destral -m crm_poweremail`: `Ran 17 tests in 157.897s - OK`

Closes #86
