### PR TITLE
Permitir ejecutar las normas del CRM cuando llega un correo

### DIFF
--- a/crm.py
+++ b/crm.py
@@ -585,8 +585,19 @@ class CrmCaseRule(osv.osv):
 
     _columns = {
         'pm_template_id': fields.many2one(
-            'poweremail.templates', 'Poweremail Template', ondelete='restrict')
+            'poweremail.templates', 'Poweremail Template', ondelete='restrict'),
+        'trg_email': fields.boolean('Email Event', help='An email event executes the rules.'),
     }
+
+    def _match_triggered_by_email_event(self, cursor, uid, action, case, context=None):
+        if not action.trg_email:
+            return True
+
+        email = context.get('email')
+        if not email:
+            return False
+
+        return True
     
     def get_email_addresses(self, cr, uid, rule_id, case, context):
         """

--- a/crm_view.xml
+++ b/crm_view.xml
@@ -68,6 +68,9 @@
 			<field name="inherit_id" ref="crm.crm_case_rule-view"/>
             <field name="type">form</field>
             <field name="arch" type="xml">
+                <xpath expr="//separator[@string='Automatic Triggers']" position="after">
+                    <field name="trg_email" colspan="2" widget="switch"/>
+                </xpath>
 				<page string="E-Mail Actions" position="replace">
 				</page>
 				<field name="act_email_cc" position="after">

--- a/migrations/5.0.26.12.0/post-0001_rule_from_email.py
+++ b/migrations/5.0.26.12.0/post-0001_rule_from_email.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from oopgrade.oopgrade import MigrationHelper
+from tools import config
+
+
+def up(cursor, installed_version):
+    if not installed_version or config.updating_all:
+        return
+
+    module = 'crm_poweremail'
+    mh = MigrationHelper(cursor, module)
+
+    file = 'crm_view.xml'
+    views = [
+        'crm_case_rule-pmail-view',
+    ]
+    mh.init_model('crm.case.rule')
+    mh.update_xml_records(xml_path=file, update_record_ids=views)
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -280,11 +280,11 @@ class PoweremailMailboxCRM(osv.osv):
             cursor, uid, case_obj.browse(cursor, uid, [case_id]),
             _('Reply'), history=True, email=email.from_.address
         )
-        # 2.5 - If pending or done set to open again
-        if case['state'] in ('pending', 'done'):
-            case_obj.case_reopen_and_notification(
-                cursor, uid, [case_id]
-            )
+
+        ctx = context.copy()
+        ctx.update({'email': email})
+        case_obj._action(cursor, uid, [(case.id, case.state)], False, context=ctx)
+
         # 3.- Emails from CC, TO and FROM
         case_data = case_obj.read(cursor, uid, case_id, ['section_id'])
         reply_to = section_obj.read(

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -283,7 +283,7 @@ class PoweremailMailboxCRM(osv.osv):
 
         ctx = context.copy()
         ctx.update({'email': email})
-        case_obj._action(cursor, uid, [(case.id, case.state)], False, context=ctx)
+        case_obj._action(cursor, uid, [(case['id'], case['state'])], False, context=ctx)
 
         # 3.- Emails from CC, TO and FROM
         case_data = case_obj.read(cursor, uid, case_id, ['section_id'])

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from __future__ import absolute_import
 from .test_crm_case_rules_match import *
+from .test_crm_action_case import *
 from destral import testing
 from destral.transaction import Transaction
 from qreu import Email

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import
+from .test_crm_case_rules_match import *
 from destral import testing
 from destral.transaction import Transaction
 from qreu import Email

--- a/tests/test_crm_action_case.py
+++ b/tests/test_crm_action_case.py
@@ -3,11 +3,6 @@ from __future__ import absolute_import
 from destral import testing
 from destral.patch import PatchNewCursors
 from signals import DB_CURSOR_COMMIT
-import six
-if six.PY2:
-    from mock import patch
-else:
-    from unittest.mock import patch
 
 
 class TestCrmActionCase(testing.OOTestCaseWithCursor):

--- a/tests/test_crm_action_case.py
+++ b/tests/test_crm_action_case.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from destral import testing
+from destral.patch import PatchNewCursors
+from signals import DB_CURSOR_COMMIT
+import six
+if six.PY2:
+    from mock import patch
+else:
+    from unittest.mock import patch
+
+
+class TestCrmActionCase(testing.OOTestCaseWithCursor):
+
+    def setUp(self):
+        super(TestCrmActionCase, self).setUp()
+        self.pool = self.openerp.pool
+        self.context = self.txn.context
+
+    def tearDown(self):
+        super(TestCrmActionCase, self).tearDown()
+
+    @PatchNewCursors()
+    def test_crm_case_reopen_case_when_email_arrives(self):
+        cursor, uid, context = self.cursor, self.uid, self.context
+        case_obj = self.pool.get('crm.case')
+        section_obj = self.pool.get('crm.case.section')
+        rule_obj = self.pool.get('crm.case.rule')
+        mailbox_obj = self.pool.get('poweremail.mailbox')
+        imd_obj = self.pool.get('ir.model.data')
+
+        acc_id = imd_obj.get_object_reference(
+            cursor, uid, 'poweremail', 'info_energia_from_email'
+        )[1]
+        ctx = context.copy()
+
+        section_id = section_obj.create(cursor, uid, {
+            'name': 'Test Section',
+            'reply_to': 'section@example.com',
+        }, context=ctx)
+
+        case_id = case_obj.create(cursor, uid, {
+            'name': 'Test Case',
+            'section_id': section_id,
+            'state': 'done',
+        }, context=ctx)
+        case = case_obj.simple_browse(cursor, uid, case_id, context=ctx)
+
+        rule_obj.create(cursor, uid, {
+            'name': 'Test Rule Open Case From Email',
+            'trg_email': True,
+            'trg_state_from': 'done',
+            'act_state': 'open',
+        }, context=ctx)
+
+        mail_source = ('S:')
+        DB_CURSOR_COMMIT.send(cursor)
+
+        # mock to avoid bug where context is not passed to the _action method
+        original_bound_method = case_obj._action
+        unbound_wrapper = getattr(original_bound_method, 'im_func',original_bound_method)
+        raw_action = unbound_wrapper
+        if getattr(unbound_wrapper, 'func_closure', None):
+            for cell in unbound_wrapper.func_closure:
+                contents = cell.cell_contents
+                if hasattr(contents, '__name__') and contents.__name__ == '_action':
+                    raw_action = contents
+                    break
+
+        def mock_action(cr, user_id, cases, state_to, scrit=None, context=None):
+            return raw_action(case_obj, cr, user_id, cases, state_to, scrit, context=context)
+
+        with patch.object(case_obj, '_action', autospec=True, side_effect=mock_action):
+            mailbox_obj.create(cursor, uid, {
+                'pem_body_text': 'Closed case reply',
+                'pem_mail_orig': mail_source,
+                'pem_account_id': acc_id,
+                'conversation_id': case.conversation_id.id,
+            }, context=ctx)
+            DB_CURSOR_COMMIT.send(cursor)
+
+        case = case_obj.simple_browse(cursor, uid, case_id, context=ctx)
+        self.assertEqual(case.state, 'open')

--- a/tests/test_crm_action_case.py
+++ b/tests/test_crm_action_case.py
@@ -56,28 +56,13 @@ class TestCrmActionCase(testing.OOTestCaseWithCursor):
         mail_source = ('S:')
         DB_CURSOR_COMMIT.send(cursor)
 
-        # mock to avoid bug where context is not passed to the _action method
-        original_bound_method = case_obj._action
-        unbound_wrapper = getattr(original_bound_method, 'im_func',original_bound_method)
-        raw_action = unbound_wrapper
-        if getattr(unbound_wrapper, 'func_closure', None):
-            for cell in unbound_wrapper.func_closure:
-                contents = cell.cell_contents
-                if hasattr(contents, '__name__') and contents.__name__ == '_action':
-                    raw_action = contents
-                    break
-
-        def mock_action(cr, user_id, cases, state_to, scrit=None, context=None):
-            return raw_action(case_obj, cr, user_id, cases, state_to, scrit, context=context)
-
-        with patch.object(case_obj, '_action', autospec=True, side_effect=mock_action):
-            mailbox_obj.create(cursor, uid, {
-                'pem_body_text': 'Closed case reply',
-                'pem_mail_orig': mail_source,
-                'pem_account_id': acc_id,
-                'conversation_id': case.conversation_id.id,
-            }, context=ctx)
-            DB_CURSOR_COMMIT.send(cursor)
+        mailbox_obj.create(cursor, uid, {
+            'pem_body_text': 'Closed case reply',
+            'pem_mail_orig': mail_source,
+            'pem_account_id': acc_id,
+            'conversation_id': case.conversation_id.id,
+        }, context=ctx)
+        DB_CURSOR_COMMIT.send(cursor)
 
         case = case_obj.simple_browse(cursor, uid, case_id, context=ctx)
         self.assertEqual(case.state, 'open')

--- a/tests/test_crm_case_rules_match.py
+++ b/tests/test_crm_case_rules_match.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from destral import testing
+import six
+if six.PY2:
+    from mock import MagicMock
+else:
+    from unittest.mock import MagicMock
+
+
+class TestCrmCaseRuleMatch(testing.OOTestCaseWithCursor):
+
+    def setUp(self):
+        super(TestCrmCaseRuleMatch, self).setUp()
+        self.pool = self.openerp.pool
+        self.context = self.txn.context
+
+        self.rule_obj = self.pool.get('crm.case.rule')
+        self.case_obj = self.pool.get('crm.case')
+        self.section_obj = self.pool.get('crm.case.section')
+
+        self.section_id = self.section_obj.create(self.cursor, self.uid, {
+            'name': 'Test Section'
+        }, context=self.context)
+
+    def tearDown(self):
+        super(TestCrmCaseRuleMatch, self).tearDown()
+
+    def test_crm_case_rule_match_triggered_by_email(self):
+        cursor, uid, context = self.cursor, self.uid, self.context
+
+        case_id = self.case_obj.create(cursor, uid, {
+            'name': 'Test Case',
+            'state': 'draft',
+            'section_id': self.section_id,
+        }, context=context)
+
+        rule_id = self.rule_obj.create(cursor, uid, {
+            'name': 'Test Rule Default',
+            'active': True,
+            'trg_email': True,
+        }, context=context)
+
+        case = self.case_obj.simple_browse(cursor, uid, case_id, context=context)
+        ctx = context.copy()
+        email = MagicMock()
+        ok = self.rule_obj.match(cursor, uid, [rule_id], case, None, context=context)
+        self.assertFalse(ok)
+        ctx.update({'email': email})
+        case = self.case_obj.simple_browse(cursor, uid, case.id, context=context)
+        ok = self.rule_obj.match(cursor, uid, [rule_id], case, None, context=ctx)
+        self.assertTrue(ok)


### PR DESCRIPTION
## Comportament nou

Permitir ejecutar las normas del CRM cuando llega un correo y la norma tiene el campo `trg_email` seleccionado.
<img width="1487" height="817" alt="image" src="https://github.com/user-attachments/assets/f2d6636c-e09a-4f4e-853c-d27624dd0e2a" />

## Comportament antic

No se ejecutaban las normas cuando llegaba un correo.

## Relacionat

- Tasca: TASK-85341
- Trello:
- Cas:
- Depèn de:

## Detalls técnics

### Afectacions / Migració de dades

- [ ] **Reiniciar serveis:**
    -  webclient-api
- [ ] **Actualizació mòduls:**
    - 
- [x] **Migració de dades**
    - 5.0.26.12.0
    - crm_poweremail   -   post-0001_add_automatic_triggers_separator.py
