### PR TITLE
Corregir correos de reglas CRM para casos ATC

### DIFF
--- a/__terp__.py
+++ b/__terp__.py
@@ -16,6 +16,10 @@
         "crm",
         "poweremail",
     ],
+    "test_depends": [
+        "giscedata_atc_distri",
+        "poweremail_references",
+    ],
     "init_xml": [],
     "demo_xml": [
         "demo/crm_demo.xml",

--- a/crm.py
+++ b/crm.py
@@ -713,9 +713,25 @@ class CrmCaseRule(osv.osv):
         if not value:
             return False
         value_template = Template(value, input_encoding='utf-8')
+        env = context.copy()
+        env.update({
+            'user': self.pool.get('res.users').simple_browse(cr, uid, uid, context=ctx),
+            'db': cr.dbname
+        })
+        values = {
+            'pool': case.pool,
+            'cursor': cr,
+            'uid': uid,
+            'peobject': case,
+            'env': env,
+            'format_exceptions': True,
+            'template': template,
+            'lang': ctx['lang']
+        }
         return value_template.render(
             object=case,
             date_now=datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+            **values
         )
 
     def _get_email_subject(

--- a/crm.py
+++ b/crm.py
@@ -7,8 +7,8 @@ from mako.template import Template
 
 from markdown import markdown
 from osv import osv, fields
+from poweremail.poweremail_core import get_email_default_lang
 from tools.translate import _
-from tools import config
 from qreu import address as qaddress
 from qreu.address import getaddresses
 
@@ -692,9 +692,8 @@ class CrmCaseRule(osv.osv):
             elif ctx.get('lang', False):
                 lang = ctx.get('lang')
             else:
-                lang = config.get('language', False) or False
-        if lang:
-            ctx['lang'] = lang
+                lang = get_email_default_lang()
+        ctx['lang'] = lang
         return ctx
 
     def _render_template_value(

--- a/crm.py
+++ b/crm.py
@@ -20,6 +20,7 @@ MARKDOWN_EXTENSIONS = [
     'markdown.extensions.sane_lists',
 ]
 MARKDOWN_TAB_LENGTH = 2
+RULE_TEMPLATE_CONTEXT_KEY = 'crm_rule_poweremail_template_id'
 
 
 class CrmCase(osv.osv):
@@ -378,9 +379,10 @@ class CrmCase(osv.osv):
             return []
 
         attachment_obj = self.pool.get('ir.attachment')
+        case_model = case._table._name
         allowed_ids = attachment_obj.search(cursor, uid, [
             ('id', 'in', attachment_ids),
-            ('res_model', '=', self._name),
+            ('res_model', '=', case_model),
             ('res_id', '=', case.id),
         ], context=context)
         allowed_ids = set(allowed_ids)
@@ -406,7 +408,13 @@ class CrmCase(osv.osv):
             context = {}
         pm_account_obj = self.pool.get('poweremail.core_accounts')
         pm_mailbox_obj = self.pool.get('poweremail.mailbox')
+        rule_obj = self.pool.get('crm.case.rule')
         attachment_obj = self.pool.get('ir.attachment')
+        crm_case = self._get_rule_history_case(
+            cursor, uid, case, context=context
+        )
+        case_model = case._table._name
+        template_id = context.get(RULE_TEMPLATE_CONTEXT_KEY, False)
         if (case.user_id and case.user_id.address_id
                 and case.user_id.address_id.email):
             emailfrom = case.user_id.address_id.email
@@ -426,7 +434,9 @@ class CrmCase(osv.osv):
                     _("Missing Poweremail-Account with Reply-To"
                       " of the Case Section."))
 
-        email_bcc = case.get_bcc_emails(context=context)
+        email_bcc = self.get_bcc_emails(
+            cursor, uid, crm_case.id, context=context
+        )
         emails = self.filter_mails(emails, emailfrom, case)
         email_cc = self.format_mails(cursor, uid, case)
         email_bcc = self.filter_mails(
@@ -438,20 +448,31 @@ class CrmCase(osv.osv):
         if signature:
             email_html_body = '{}\n-- \n{}'.format(email_html_body, signature)
 
+        subject = False
+        if template_id:
+            subject = rule_obj._get_email_subject(
+                cursor, uid, template_id, case, context=context
+            )
+        if not subject:
+            subject = self.get_subject_mail_from_case(
+                cursor, uid, case, context=context
+            )
+
         pm_mail_id = pm_mailbox_obj.create(cursor, uid, {
             'pem_from': emailfrom,
             'pem_to': ', '.join(set(emails)),
-            'pem_subject': '[%d] %s' % (case.id, case.name.encode('utf8')),
+            'pem_subject': subject,
             'pem_body_text': body,
             'pem_body_html': email_html_body,
             'pem_account_id': pem_account_id[0],
             'folder': 'outbox',
             'date_mail': datetime.now().strftime('%Y-%m-%d'),
-            'pem_message_id': make_msgid('tinycrm-%s' % case.id),
-            'conversation_id': case.conversation_id.id,
+            'pem_message_id': make_msgid('tinycrm-%s' % crm_case.id),
+            'conversation_id': crm_case.conversation_id.id,
             'pem_cc': ', '.join(set(email_cc)),
             'pem_bcc': ', '.join(set(email_bcc)),
-            'reference': 'crm.case,{}'.format(case.id),
+            'reference': '{},{}'.format(case_model, case.id),
+            'template_id': template_id,
         })
 
         attachment_ids = list(context.get('attachment_ids', []))
@@ -587,6 +608,23 @@ class CrmCaseRule(osv.osv):
         'pm_template_id': fields.many2one(
             'poweremail.templates', 'Poweremail Template', ondelete='restrict')
     }
+
+    def execute(self, cursor, uid, ids, case, context=None):
+        if context is None:
+            context = {}
+        if isinstance(ids, list) and len(ids) == 1:
+            rule_id = ids[0]
+        else:
+            raise ValueError("Multiple ids is not supported")
+        template_id = self.read(
+            cursor, uid, rule_id, ['pm_template_id'], context=context
+        )['pm_template_id']
+        rule_context = context.copy()
+        if template_id:
+            rule_context[RULE_TEMPLATE_CONTEXT_KEY] = template_id[0]
+        return super(CrmCaseRule, self).execute(
+            cursor, uid, ids, case, context=rule_context
+        )
     
     def get_email_addresses(self, cr, uid, rule_id, case, context):
         """
@@ -637,63 +675,75 @@ class CrmCaseRule(osv.osv):
 
         return list(set(emails))
 
+    def _get_template_context(
+            self, cr, uid, template, case, context=None):
+        if context is None:
+            context = {}
+        pm_send_wizard_obj = self.pool.get('poweremail.send.wizard')
+        ctx = context.copy()
+        lang = pm_send_wizard_obj.get_value(
+            cr, uid, template, template.lang, context, id=case.id
+        )
+        if not lang:
+            if case.partner_id and case.partner_id.lang:
+                lang = case.partner_id.lang
+            elif case.user_id and case.user_id.context_lang:
+                lang = case.user_id.context_lang
+            elif ctx.get('lang', False):
+                lang = ctx.get('lang')
+            else:
+                lang = config.get('language', False) or False
+        if lang:
+            ctx['lang'] = lang
+        return ctx
+
+    def _render_template_value(
+            self, cr, uid, template_id, field_name, case, fallback=False,
+            context=None):
+        pm_template_obj = self.pool.get('poweremail.templates')
+        template = pm_template_obj.browse(
+            cr, uid, template_id, context=context
+        )
+        ctx = self._get_template_context(
+            cr, uid, template, case, context=context
+        )
+        value = pm_template_obj.read(
+            cr, uid, template_id, [field_name], context=ctx
+        )[field_name] or fallback
+        if not value:
+            return False
+        value_template = Template(value, input_encoding='utf-8')
+        return value_template.render(
+            object=case,
+            date_now=datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+        )
+
+    def _get_email_subject(
+            self, cr, uid, template_id, case, context=None):
+        return self._render_template_value(
+            cr, uid, template_id, 'def_subject', case, context=context
+        )
+
     def get_email_body(self, cr, uid, rule_id, case, context=None):
-        """
-        Override CRM.Case get_email_body
-        Gets the body from the template on the rule and renders it with the
-        case values, updating the context language with the case language
-        :param cr:      OpenERP Cursor
-        :param uid:     OpenERP User ID
-        :param rule_id: OpenERP action (Crm.Case.Rule) ID
-        :param case:    OpenERP case (Crm.Case) browse record
-        :param context: OpenERP Context
-        :return:        The rendered body for the template referenced on the rule
-        """
-        if not context:
+        """Render the rule template body with the functional record."""
+        if context is None:
             context = {}
         if isinstance(rule_id, list):
             rule_id = rule_id[0]
         if isinstance(case, list):
             case = case[0]
         action_body = super(CrmCaseRule, self).get_email_body(
-            cr, uid, rule_id, case, context)
-        action_template = self.read(
-            cr, uid, rule_id, ['pm_template_id'])['pm_template_id']
-        if not action_template:
-            return action_body
-        else:
-            action_template = action_template[0]
-        pm_template_obj = self.pool.get('poweremail.templates')
-        pm_template = pm_template_obj.browse(cr, uid, action_template)
-        pm_send_wizard_obj = self.pool.get('poweremail.send.wizard')
-        ctx = context.copy()
-        # Get lang from template
-        lang = pm_send_wizard_obj.get_value(
-            cr, uid, pm_template, pm_template.lang, context, id=case.id)
-        if not lang:
-            # Get lang from case.partner_id (source)
-            if case.partner_id and case.partner_id.lang:
-                lang = case.partner_id.lang
-            # Get lang from case.user_id (responsible)
-            elif case.user_id and case.user_id.context_lang:
-                lang = case.user_id.context_lang
-            # Get lang from Context (Server-based)
-            elif ctx.get('lang', False):
-                lang = ctx.get('lang')
-            # Get lang from config file
-            else:
-                lang = config.get('language', False) or False
-        if lang:
-            ctx['lang'] = lang
-        template_body = pm_template_obj.read(
-            cr, uid, action_template, ['def_body_text'], ctx)['def_body_text']
-        body = template_body or action_body
-        body_mako_tpl = Template(body, input_encoding='utf-8')
-        rendered_body = body_mako_tpl.render(
-            object=case,
-            date_now=datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+            cr, uid, rule_id, case, context
         )
-        return rendered_body
+        template_id = self.read(
+            cr, uid, rule_id, ['pm_template_id'], context=context
+        )['pm_template_id']
+        if not template_id:
+            return action_body
+        return self._render_template_value(
+            cr, uid, template_id[0], 'def_body_text', case,
+            fallback=action_body, context=context
+        )
 
 
 CrmCaseRule()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,8 @@
 # coding=utf-8
+from __future__ import absolute_import
+
+from .test_atc_crm_rule_email import *
+
 from destral import testing
 from destral.transaction import Transaction
 from qreu import Email

--- a/tests/test_atc_crm_rule_email.py
+++ b/tests/test_atc_crm_rule_email.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from destral.patch import PatchNewCursors
+from destral.testing import OOTestCaseWithCursor
+from oorq.oorq import AsyncMode
+
+
+class TestAtcCrmRuleEmail(OOTestCaseWithCursor):
+
+    def setUp(self):
+        super(TestAtcCrmRuleEmail, self).setUp()
+        self.context = self.txn.context
+        self.pool = self.openerp.pool
+        self.atc_obj = self.pool.get('giscedata.atc')
+        self.crm_obj = self.pool.get('crm.case')
+        self.rule_obj = self.pool.get('crm.case.rule')
+        self.template_obj = self.pool.get('poweremail.templates')
+        self.mailbox_obj = self.pool.get('poweremail.mailbox')
+        self.log_obj = self.pool.get('crm.case.log')
+
+        address_obj = self.pool.get('res.partner.address')
+        user_obj = self.pool.get('res.users')
+        user = user_obj.simple_browse(
+            self.cursor, self.uid, self.uid, context=self.context
+        )
+        if not user.address_id:
+            address_id = address_obj.create(
+                self.cursor, self.uid, {
+                    'name': 'CRM rule test user',
+                    'email': 'agent@example.com',
+                }, context=self.context
+            )
+            user_obj.write(
+                self.cursor, self.uid, [self.uid],
+                {'address_id': address_id}, context=self.context
+            )
+
+        section_obj = self.pool.get('crm.case.section')
+        self.section_id = section_obj.create(
+            self.cursor, self.uid, {
+                'name': 'ATC PowerEmail rules test',
+                'reply_to': 'atc-rules@example.com',
+            }, context=self.context
+        )
+        account_obj = self.pool.get('poweremail.core_accounts')
+        self.account_id = account_obj.create(
+            self.cursor, self.uid, {
+                'name': 'ATC PowerEmail rules test',
+                'email_id': 'atc-rules@example.com',
+                'user': self.uid,
+                'company': 'yes',
+                'smtpserver': 'localhost',
+                'smtpport': 25,
+            }, context=self.context
+        )
+
+    def _create_atc_with_distinct_crm_id(self):
+        values = {
+            'name': 'ATC PowerEmail rule case',
+            'section_id': self.section_id,
+            'state': 'draft',
+        }
+        atc_id = self.atc_obj.create(
+            self.cursor, self.uid, values, context=self.context
+        )
+        crm_id = self.atc_obj.read(
+            self.cursor, self.uid, atc_id, ['crm_id'], context=self.context
+        )['crm_id'][0]
+        if atc_id == crm_id:
+            self.crm_obj.create(
+                self.cursor, self.uid, {
+                    'name': 'CRM sequence offset',
+                    'section_id': self.section_id,
+                    'state': 'draft',
+                }, context=self.context
+            )
+            atc_id = self.atc_obj.create(
+                self.cursor, self.uid, values, context=self.context
+            )
+            crm_id = self.atc_obj.read(
+                self.cursor, self.uid, atc_id, ['crm_id'],
+                context=self.context
+            )['crm_id'][0]
+        self.assertNotEqual(atc_id, crm_id)
+        return atc_id, crm_id
+
+    def _create_template_and_rule(
+            self, model_name, subject, state_from):
+        model_ids = self.pool.get('ir.model').search(
+            self.cursor, self.uid, [('model', '=', model_name)], limit=1,
+            context=self.context
+        )
+        self.assertEqual(len(model_ids), 1)
+        template_id = self.template_obj.create(
+            self.cursor, self.uid, {
+                'name': 'CRM rule template {}'.format(model_name),
+                'object_name': model_ids[0],
+                'def_to': 'recipient@example.com',
+                'def_subject': subject,
+                'def_body_text': 'Body for ${object.name}',
+                'pem_account_id': self.account_id,
+            }, context=self.context
+        )
+        self.rule_obj.create(
+            self.cursor, self.uid, {
+                'name': 'CRM rule email {}'.format(model_name),
+                'trg_section_id': self.section_id,
+                'trg_state_from': state_from,
+                'trg_state_to': 'done',
+                'pm_template_id': template_id,
+            }, context=self.context
+        )
+        return template_id
+
+    def _assert_rule_email(
+            self, record_id, crm_id, transition, model_name, subject,
+            template_id):
+        previous_log_ids = set(self.log_obj.search(
+            self.cursor, self.uid, [('name', '=', 'Rule')],
+            context=self.context
+        ))
+        with AsyncMode(mode='sync'), PatchNewCursors():
+            transition(
+                self.cursor, self.uid, [record_id], context=self.context
+            )
+
+        mailbox_ids = self.mailbox_obj.search(
+            self.cursor, self.uid, [
+                ('reference', '=', '{},{}'.format(model_name, record_id)),
+                ('folder', '=', 'outbox'),
+            ], context=self.context
+        )
+        self.assertEqual(len(mailbox_ids), 1)
+        mailbox = self.mailbox_obj.read(
+            self.cursor, self.uid, mailbox_ids[0], [
+                'pem_subject', 'pem_body_text', 'pem_message_id',
+                'reference', 'template_id',
+            ], context=self.context
+        )
+        self.assertEqual(mailbox['pem_subject'], subject)
+        self.assertEqual(mailbox['template_id'][0], template_id)
+        self.assertEqual(
+            mailbox['reference'], '{},{}'.format(model_name, record_id)
+        )
+        self.assertIn('Body for', mailbox['pem_body_text'])
+        self.assertIn('tinycrm-{}'.format(crm_id), mailbox['pem_message_id'])
+
+        current_log_ids = set(self.log_obj.search(
+            self.cursor, self.uid, [('name', '=', 'Rule')],
+            context=self.context
+        ))
+        rule_log_ids = current_log_ids - previous_log_ids
+        self.assertEqual(len(rule_log_ids), 1)
+        rule_log = self.log_obj.read(
+            self.cursor, self.uid, rule_log_ids.pop(), ['case_id'],
+            context=self.context
+        )
+        self.assertEqual(rule_log['case_id'][0], crm_id)
+
+    def test_atc_rule_email_uses_template_and_functional_reference(self):
+        atc_id, crm_id = self._create_atc_with_distinct_crm_id()
+        subject = 'ATC {} - ${{object.name}}'.format(atc_id)
+        expected_subject = 'ATC {} - ATC PowerEmail rule case'.format(atc_id)
+        template_id = self._create_template_and_rule(
+            'giscedata.atc', subject, 'done'
+        )
+        self._assert_rule_email(
+            atc_id, crm_id, self.atc_obj.atc_close,
+            'giscedata.atc', expected_subject, template_id
+        )
+
+    def test_crm_rule_email_keeps_crm_compatibility(self):
+        crm_id = self.crm_obj.create(
+            self.cursor, self.uid, {
+                'name': 'CRM PowerEmail rule case',
+                'section_id': self.section_id,
+                'state': 'draft',
+            }, context=self.context
+        )
+        subject = 'CRM {} - ${{object.name}}'.format(crm_id)
+        expected_subject = 'CRM {} - CRM PowerEmail rule case'.format(crm_id)
+        template_id = self._create_template_and_rule(
+            'crm.case', subject, 'draft'
+        )
+        def close_case(cursor, uid, ids, context=None):
+            return self.crm_obj.case_close(cursor, uid, ids)
+
+        self._assert_rule_email(
+            crm_id, crm_id, close_case,
+            'crm.case', expected_subject, template_id
+        )

--- a/tests/test_atc_crm_rule_email.py
+++ b/tests/test_atc_crm_rule_email.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+import base64
+
 from destral.patch import PatchNewCursors
 from destral.testing import OOTestCaseWithCursor
 from oorq.oorq import AsyncMode
@@ -86,7 +88,8 @@ class TestAtcCrmRuleEmail(OOTestCaseWithCursor):
         return atc_id, crm_id
 
     def _create_template_and_rule(
-            self, model_name, subject, state_from):
+            self, model_name, subject, state_from,
+            body='Body for ${object.name}'):
         model_ids = self.pool.get('ir.model').search(
             self.cursor, self.uid, [('model', '=', model_name)], limit=1,
             context=self.context
@@ -98,7 +101,7 @@ class TestAtcCrmRuleEmail(OOTestCaseWithCursor):
                 'object_name': model_ids[0],
                 'def_to': 'recipient@example.com',
                 'def_subject': subject,
-                'def_body_text': 'Body for ${object.name}',
+                'def_body_text': body,
                 'pem_account_id': self.account_id,
             }, context=self.context
         )
@@ -115,7 +118,7 @@ class TestAtcCrmRuleEmail(OOTestCaseWithCursor):
 
     def _assert_rule_email(
             self, record_id, crm_id, transition, model_name, subject,
-            template_id):
+            template_id, attachment_id=False):
         previous_log_ids = set(self.log_obj.search(
             self.cursor, self.uid, [('name', '=', 'Rule')],
             context=self.context
@@ -135,7 +138,7 @@ class TestAtcCrmRuleEmail(OOTestCaseWithCursor):
         mailbox = self.mailbox_obj.read(
             self.cursor, self.uid, mailbox_ids[0], [
                 'pem_subject', 'pem_body_text', 'pem_message_id',
-                'reference', 'template_id',
+                'pem_attachments_ids', 'reference', 'template_id',
             ], context=self.context
         )
         self.assertEqual(mailbox['pem_subject'], subject)
@@ -145,6 +148,8 @@ class TestAtcCrmRuleEmail(OOTestCaseWithCursor):
         )
         self.assertIn('Body for', mailbox['pem_body_text'])
         self.assertIn('tinycrm-{}'.format(crm_id), mailbox['pem_message_id'])
+        if attachment_id:
+            self.assertIn(attachment_id, mailbox['pem_attachments_ids'])
 
         current_log_ids = set(self.log_obj.search(
             self.cursor, self.uid, [('name', '=', 'Rule')],
@@ -162,12 +167,25 @@ class TestAtcCrmRuleEmail(OOTestCaseWithCursor):
         atc_id, crm_id = self._create_atc_with_distinct_crm_id()
         subject = 'ATC {} - ${{object.name}}'.format(atc_id)
         expected_subject = 'ATC {} - ATC PowerEmail rule case'.format(atc_id)
+        attachment_id = self.pool.get('ir.attachment').create(
+            self.cursor, self.uid, {
+                'name': 'ATC rule attachment',
+                'datas_fname': 'atc-rule.txt',
+                'datas': base64.b64encode(b'ATC rule attachment'),
+                'res_model': 'giscedata.atc',
+                'res_id': atc_id,
+            }, context=self.context
+        )
+        body = 'Body for ${{object.name}}\n\n![proof](attachment://{})'.format(
+            attachment_id
+        )
         template_id = self._create_template_and_rule(
-            'giscedata.atc', subject, 'done'
+            'giscedata.atc', subject, 'done', body=body
         )
         self._assert_rule_email(
             atc_id, crm_id, self.atc_obj.atc_close,
-            'giscedata.atc', expected_subject, template_id
+            'giscedata.atc', expected_subject, template_id,
+            attachment_id=attachment_id
         )
 
     def test_crm_rule_email_keeps_crm_compatibility(self):


### PR DESCRIPTION
# :warning: EN CASO DE ERROR

## Causa del error

La integración de `crm.case.rule` con PowerEmail asumía que el registro funcional siempre era un `crm.case` y no conservaba la plantilla seleccionada por la regla. En los casos ATC delegados mediante `_inherits`, esto provocaba que el buzón se vinculase al padre CRM, se perdiese `template_id` y el asunto se sustituyese por el genérico del caso.

## Cómo reproducir el error

1. Configurar una regla CRM aplicable a `giscedata.atc` con una plantilla PowerEmail cuyo asunto contenga variables Mako.
2. Ejecutar una transición de estado ATC que active la regla.
3. Comprobar el `poweremail.mailbox` generado: el asunto no corresponde a la plantilla, falta `template_id` y la referencia apunta al padre `crm.case`.

## Origen del error

Es una limitación previa de la integración entre `crm_poweremail` y la herencia delegada de CRM, expuesta al ejecutar reglas CRM desde ATC en [gisce/erp#28758](https://github.com/gisce/erp/pull/28758).

## Comportamiento nuevo

- La regla propaga el identificador de la plantilla hasta el envío PowerEmail.
- Asunto y cuerpo se renderizan con el mismo idioma y contexto Mako.
- El buzón conserva como referencia el registro funcional `giscedata.atc`.
- La conversación y el `Message-Id` continúan ligados al padre `crm.case` para preservar el threading existente.
- Los adjuntos Markdown se buscan sobre el modelo funcional, también para casos heredados.
- El comportamiento de las reglas ejecutadas directamente sobre `crm.case` se mantiene.

## Relacionado

- Tarea: TASK-93257
- Issue: [gisce/erp#28756](https://github.com/gisce/erp/issues/28756)
- Depende de: [gisce/erp#28758](https://github.com/gisce/erp/pull/28758)

Requested by: @joanperez1

## Detalles técnicos

### Afectaciones / Migración de datos

- [x] **Reiniciar servicios:** procesos que cargan `crm_poweremail`.
- [ ] **Actualización de módulos.**
- [ ] **Migración de datos.**

No hay cambios de esquema, XML ni datos instalados.

### Pruebas

- `TestAtcCrmRuleEmail`: 2 pruebas end-to-end correctas en Python 2 para ATC y compatibilidad con `crm.case`.
- Cobertura de asunto y cuerpo renderizados, `template_id`, referencia funcional, threading, historial y adjuntos Markdown.
- `py_compile` correcto con Python 2 y Python 3 para el código y las pruebas modificadas.
- La clase legacy `TestCrmCaseRule` no llega a ejecutar sus pruebas porque su fixture existente no informa el campo obligatorio `company` de `poweremail.core_accounts`; el error ocurre durante el setup y no se ha alterado dentro de esta tarea.

## Checklist

- [x] Test code
- [ ] Verificado con cliente
